### PR TITLE
[FAU-423] Use `<TextControl>` for duration of studies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make "Duration of studies in semester" a single line input. 
+
 ## [1.2.7] - 2023-11-23
 
 ### Fixed

--- a/resources/ts/components/DegreeProgramEditForm/General.tsx
+++ b/resources/ts/components/DegreeProgramEditForm/General.tsx
@@ -432,7 +432,7 @@ const General = () => {
 						fill="full"
 						required
 					>
-						<TextareaControlFormField
+						<TextControl
 							onChange={ ( value: string ) => {
 								handleChange< string >(
 									'standard_duration',

--- a/tests/js/unit/components/DegreeProgramEditForm/__snapshots__/AdmissionRequirements.test.tsx.snap
+++ b/tests/js/unit/components/DegreeProgramEditForm/__snapshots__/AdmissionRequirements.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Admission requirement fields should match snapshot 1`] = `
       data-wp-component="Flex"
     >
       <div
-        className="components-flex-item sc-dkrFOg kGelRu css-mw3lhz-View-Item-sx-Base e19lxcc00"
+        className="components-flex-item sc-dkrFOg gJXaeq css-mw3lhz-View-Item-sx-Base e19lxcc00"
         data-wp-c16t={true}
         data-wp-component="FlexItem"
         fill="half"
@@ -47,7 +47,7 @@ exports[`Admission requirement fields should match snapshot 1`] = `
         </div>
       </div>
       <div
-        className="components-flex-item sc-dkrFOg kGelRu css-mw3lhz-View-Item-sx-Base e19lxcc00"
+        className="components-flex-item sc-dkrFOg gJXaeq css-mw3lhz-View-Item-sx-Base e19lxcc00"
         data-wp-c16t={true}
         data-wp-component="FlexItem"
         fill="half"
@@ -81,7 +81,7 @@ exports[`Admission requirement fields should match snapshot 1`] = `
         </div>
       </div>
       <div
-        className="components-flex-item sc-dkrFOg hXHKKq css-mw3lhz-View-Item-sx-Base e19lxcc00"
+        className="components-flex-item sc-dkrFOg dgWbYO css-mw3lhz-View-Item-sx-Base e19lxcc00"
         data-wp-c16t={true}
         data-wp-component="FlexItem"
         fill="full"
@@ -89,7 +89,7 @@ exports[`Admission requirement fields should match snapshot 1`] = `
         <hr />
       </div>
       <div
-        className="components-flex-item sc-dkrFOg hXHKKq css-mw3lhz-View-Item-sx-Base e19lxcc00"
+        className="components-flex-item sc-dkrFOg dgWbYO css-mw3lhz-View-Item-sx-Base e19lxcc00"
         data-wp-c16t={true}
         data-wp-component="FlexItem"
         fill="full"
@@ -123,7 +123,7 @@ exports[`Admission requirement fields should match snapshot 1`] = `
         </div>
       </div>
       <div
-        className="components-flex-item sc-dkrFOg hXHKKq css-mw3lhz-View-Item-sx-Base e19lxcc00"
+        className="components-flex-item sc-dkrFOg dgWbYO css-mw3lhz-View-Item-sx-Base e19lxcc00"
         data-wp-c16t={true}
         data-wp-component="FlexItem"
         fill="full"
@@ -152,7 +152,7 @@ exports[`Admission requirement fields should match snapshot 1`] = `
         </div>
       </div>
       <div
-        className="components-flex-item sc-dkrFOg hXHKKq css-mw3lhz-View-Item-sx-Base e19lxcc00"
+        className="components-flex-item sc-dkrFOg dgWbYO css-mw3lhz-View-Item-sx-Base e19lxcc00"
         data-wp-c16t={true}
         data-wp-component="FlexItem"
         fill="full"
@@ -160,7 +160,7 @@ exports[`Admission requirement fields should match snapshot 1`] = `
         <hr />
       </div>
       <div
-        className="components-flex-item sc-dkrFOg hXHKKq css-mw3lhz-View-Item-sx-Base e19lxcc00"
+        className="components-flex-item sc-dkrFOg dgWbYO css-mw3lhz-View-Item-sx-Base e19lxcc00"
         data-wp-c16t={true}
         data-wp-component="FlexItem"
         fill="full"
@@ -207,7 +207,7 @@ exports[`Admission requirement fields should match snapshot 1`] = `
         </div>
       </div>
       <div
-        className="components-flex-item sc-dkrFOg hXHKKq css-mw3lhz-View-Item-sx-Base e19lxcc00"
+        className="components-flex-item sc-dkrFOg dgWbYO css-mw3lhz-View-Item-sx-Base e19lxcc00"
         data-wp-c16t={true}
         data-wp-component="FlexItem"
         fill="full"
@@ -253,7 +253,7 @@ exports[`Admission requirement fields should match snapshot 1`] = `
         </div>
       </div>
       <div
-        className="components-flex-item sc-dkrFOg hXHKKq css-mw3lhz-View-Item-sx-Base e19lxcc00"
+        className="components-flex-item sc-dkrFOg dgWbYO css-mw3lhz-View-Item-sx-Base e19lxcc00"
         data-wp-c16t={true}
         data-wp-component="FlexItem"
         fill="full"
@@ -261,7 +261,7 @@ exports[`Admission requirement fields should match snapshot 1`] = `
         <hr />
       </div>
       <div
-        className="components-flex-item sc-dkrFOg hXHKKq css-mw3lhz-View-Item-sx-Base e19lxcc00"
+        className="components-flex-item sc-dkrFOg dgWbYO css-mw3lhz-View-Item-sx-Base e19lxcc00"
         data-wp-c16t={true}
         data-wp-component="FlexItem"
         fill="full"
@@ -290,7 +290,7 @@ exports[`Admission requirement fields should match snapshot 1`] = `
         </div>
       </div>
       <div
-        className="components-flex-item sc-dkrFOg hXHKKq css-mw3lhz-View-Item-sx-Base e19lxcc00"
+        className="components-flex-item sc-dkrFOg dgWbYO css-mw3lhz-View-Item-sx-Base e19lxcc00"
         data-wp-c16t={true}
         data-wp-component="FlexItem"
         fill="full"
@@ -319,7 +319,7 @@ exports[`Admission requirement fields should match snapshot 1`] = `
         </div>
       </div>
       <div
-        className="components-flex-item sc-dkrFOg hXHKKq css-mw3lhz-View-Item-sx-Base e19lxcc00"
+        className="components-flex-item sc-dkrFOg dgWbYO css-mw3lhz-View-Item-sx-Base e19lxcc00"
         data-wp-c16t={true}
         data-wp-component="FlexItem"
         fill="full"
@@ -348,7 +348,7 @@ exports[`Admission requirement fields should match snapshot 1`] = `
         </div>
       </div>
       <div
-        className="components-flex-item sc-dkrFOg hXHKKq css-mw3lhz-View-Item-sx-Base e19lxcc00"
+        className="components-flex-item sc-dkrFOg dgWbYO css-mw3lhz-View-Item-sx-Base e19lxcc00"
         data-wp-c16t={true}
         data-wp-component="FlexItem"
         fill="full"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-423
"Duration of studies in semester" field is a multi-line input (`<TextareaControlFormField>`).


**What is the new behavior (if this is a feature change)?**
"Duration of studies in semester" field is a single-line input (`<TextControl>`).


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, existing content will be kept.

Before:
<img width="1393" alt="Bildschirmfoto 2024-05-03 um 11 46 20" src="https://github.com/RRZE-Webteam/FAU-Studium/assets/8144115/2090c79b-7df0-442f-8133-db4b552775fa">

After:
<img width="1394" alt="Bildschirmfoto 2024-05-03 um 11 48 00" src="https://github.com/RRZE-Webteam/FAU-Studium/assets/8144115/c5e35335-260e-462e-988e-e9232674c706">


**Other information**:
There's currently an unrelated error preventing any input ([source](https://inpsyde.slack.com/archives/C045KFJ9MB5/p1714728160353629)). However, this shouldn't affect this change (or vice versa).