### PR TITLE
[FAU-422] Support core "Quote" block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support WordPress "Quote" block in content fields.
+
 ## [1.2.7] - 2023-11-23
 
 ### Fixed

--- a/composer.lock
+++ b/composer.lock
@@ -407,16 +407,16 @@
         },
         {
             "name": "rrze/fau-studium-common",
-            "version": "dev-main",
+            "version": "dev-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/RRZE-Webteam/FAU-Studium-Common.git",
-                "reference": "2cef39901512f7b0c61ac8f319a6ff61039c60e0"
+                "reference": "b75b9ed658076304632b90d897ba3faba1bedb46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/RRZE-Webteam/FAU-Studium-Common/zipball/2cef39901512f7b0c61ac8f319a6ff61039c60e0",
-                "reference": "2cef39901512f7b0c61ac8f319a6ff61039c60e0",
+                "url": "https://api.github.com/repos/RRZE-Webteam/FAU-Studium-Common/zipball/b75b9ed658076304632b90d897ba3faba1bedb46",
+                "reference": "b75b9ed658076304632b90d897ba3faba1bedb46",
                 "shasum": ""
             },
             "require": {
@@ -480,10 +480,10 @@
             ],
             "description": "Shared kernel for FAU Degree Program and FAU Degree Program Output plugins.",
             "support": {
-                "source": "https://github.com/RRZE-Webteam/FAU-Studium-Common/tree/main",
+                "source": "https://github.com/RRZE-Webteam/FAU-Studium-Common/tree/dev",
                 "issues": "https://github.com/RRZE-Webteam/FAU-Studium-Common/issues"
             },
-            "time": "2024-04-29T08:12:47+00:00"
+            "time": "2024-05-07T13:49:54+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/resources/ts/components/ContentField/constants.ts
+++ b/resources/ts/components/ContentField/constants.ts
@@ -5,6 +5,7 @@ export const ALLOWED_BLOCK_TYPES = [
 	'core/list-item',
 	'core/heading',
 	'core/shortcode',
+	'core/quote',
 	'fau/description-list',
 	'fau/description-term',
 	'fau/description-details',

--- a/resources/ts/components/TextControlCollection/TextControlCollection.tsx
+++ b/resources/ts/components/TextControlCollection/TextControlCollection.tsx
@@ -73,7 +73,7 @@ const TextControlCollection = ( {
 		onChange(
 			fields.filter( ( f ) => !! f.value ).map( ( f ) => f.value )
 		);
-	}, [ fields, onChange ] );
+	}, [ fields ] );
 
 	const { required } = useFieldContext();
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-422
The "Quote" block is not supported in content fields.


**What is the new behavior (if this is a feature change)?**
The "Quote" block is supported and persisted in content fields.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
* Related, dependent PR: https://github.com/RRZE-Webteam/FAU-Studium-Common/pull/4
* As part of the Boy Scout rule, this PR also includes a fix for a [regression](https://github.com/RRZE-Webteam/FAU-Studium/pull/126/files#diff-0ae0ae0c0112d35ae677c42ffc0b492fb324d7ce75f66193f6160b2a301da3e1R76) introduced in #126 ([internal discussion](https://inpsyde.slack.com/archives/C045KFJ9MB5/p1714728160353629))