### PR TITLE
[FAU-411] Add campo-key field / Add form fields validation rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Campo-Key term meta field.
+- Term meta fields validation rules.
+
 ## [1.2.7] - 2023-11-23
 
 ### Fixed

--- a/resources/scss/term-meta-fields-validation.scss
+++ b/resources/scss/term-meta-fields-validation.scss
@@ -1,8 +1,8 @@
-.form-invalid > input[type=text] {
-    border-color: #d63638 !important;
-    box-shadow: 0 0 2px rgba(214, 54, 56, 0.8);
+.form-invalid > input[type="text"] {
+	border-color: #d63638 !important;
+	box-shadow: 0 0 2px rgba(214, 54, 56, 0.8);
 }
 
 .term-meta-validation-errors {
-    color: #d63638;
+	color: #d63638;
 }

--- a/resources/scss/term-meta-fields-validation.scss
+++ b/resources/scss/term-meta-fields-validation.scss
@@ -1,0 +1,8 @@
+.form-invalid > input[type=text] {
+    border-color: #d63638 !important;
+    box-shadow: 0 0 2px rgba(214, 54, 56, 0.8);
+}
+
+.term-meta-validation-errors {
+    color: #d63638;
+}

--- a/resources/ts/components/ContentField/styles.scss
+++ b/resources/ts/components/ContentField/styles.scss
@@ -1,5 +1,7 @@
-// Unfortunately, there is no way to filter or adjust the core blocks toolbar.
-// Hiding the block toolbar items is fragile, so it is merely a UX improvement,
+// Unfortunately, there is no way to filter
+// or adjust the core blocks toolbar.
+// Hiding the block toolbar items is fragile,
+// so it is merely a UX improvement,
 // with the actual sanitization happening server-side.
 
 // Hide H1, H2 and H6 Heading level toolbar buttons

--- a/resources/ts/term-meta-fields-validation.ts
+++ b/resources/ts/term-meta-fields-validation.ts
@@ -1,0 +1,126 @@
+import domReady from '@wordpress/dom-ready';
+import type { ValidationRule } from './validation/defs';
+import { isInputValid } from './validation/formFieldValidationRules';
+
+const SUBMIT_BUTTON_SELECTOR = '#submit';
+const VALIDATION_ERRROS_CLASSNAME = 'term-meta-validation-errors';
+
+declare global {
+	interface Window {
+		termMetaValidationRules?: Record< string, ValidationRule[] >;
+	}
+}
+
+const errors = new Map< string, Map< string, string > >();
+
+const renderErrors = ( fieldName: string ) => {
+	const fieldWrapper = document
+		.querySelector< HTMLDivElement >( `[name="${ fieldName }"]` )
+		?.closest< HTMLDivElement >( '.form-field' );
+
+	if ( ! fieldWrapper ) {
+		return;
+	}
+
+	let validationErrors = fieldWrapper.querySelector< HTMLUListElement >(
+		`.${ VALIDATION_ERRROS_CLASSNAME }`
+	);
+	const fieldErrors = errors.get( fieldName );
+
+	if ( ! fieldErrors || fieldErrors.size === 0 ) {
+		validationErrors?.remove();
+		fieldWrapper.classList.remove( 'form-invalid' );
+		return;
+	}
+
+	if ( ! validationErrors ) {
+		validationErrors = document.createElement( 'ul' );
+		validationErrors.classList.add( VALIDATION_ERRROS_CLASSNAME );
+	}
+
+	validationErrors.innerHTML = '';
+
+	fieldWrapper.classList.add( 'form-invalid' );
+
+	fieldErrors.forEach( ( errorMessage ) => {
+		const errorItemElement = document.createElement( 'li' );
+		errorItemElement.classList.add( 'form-invalid-message' );
+		errorItemElement.textContent = errorMessage;
+		( validationErrors as HTMLUListElement ).appendChild(
+			errorItemElement
+		);
+	} );
+
+	fieldWrapper.appendChild( validationErrors );
+};
+
+const disableSubmit = () => {
+	const submitButton = document.querySelector<
+		HTMLInputElement | HTMLButtonElement
+	>( SUBMIT_BUTTON_SELECTOR );
+
+	if ( ! submitButton ) {
+		return;
+	}
+
+	submitButton.disabled = true;
+};
+
+const enableSubmit = () => {
+	const submitButton = document.querySelector<
+		HTMLInputElement | HTMLButtonElement
+	>( SUBMIT_BUTTON_SELECTOR );
+
+	if ( ! submitButton ) {
+		return;
+	}
+
+	submitButton.disabled = false;
+};
+
+const validateInput = ( input: HTMLElement, rules: ValidationRule[] ) => {
+	if ( ! ( input instanceof HTMLInputElement ) ) {
+		return;
+	}
+
+	const fieldErrors = errors.get( input.name ) || new Map< string, string >();
+
+	rules.forEach( ( rule ) => {
+		if ( ! isInputValid( input.value, rule ) ) {
+			fieldErrors.set( rule.name, rule.errorMessage );
+			disableSubmit();
+			return;
+		}
+
+		fieldErrors.delete( rule.name );
+	} );
+
+	errors.set( input.name, fieldErrors );
+	renderErrors( input.name );
+
+	if ( fieldErrors.size === 0 ) {
+		enableSubmit();
+	}
+};
+
+domReady( () => {
+	if ( typeof window.termMetaValidationRules === 'undefined' ) {
+		return;
+	}
+
+	Object.entries( window.termMetaValidationRules ).forEach(
+		( [ key, rules ] ) => {
+			const input = document.querySelector< HTMLInputElement >(
+				`input[name="${ key }"]`
+			);
+
+			if ( ! input ) {
+				return;
+			}
+
+			input.addEventListener( 'input', ( event ) => {
+				validateInput( event.target as HTMLElement, rules );
+			} );
+		}
+	);
+} );

--- a/resources/ts/validation/defs.ts
+++ b/resources/ts/validation/defs.ts
@@ -1,0 +1,5 @@
+export type ValidationRule = {
+	errorMessage: string;
+	name: string;
+	payload: Record< string, unknown >;
+};

--- a/resources/ts/validation/formFieldValidationRules.ts
+++ b/resources/ts/validation/formFieldValidationRules.ts
@@ -75,5 +75,5 @@ export const isInputValid = (
 		return validator( value, validationRule.payload.value );
 	}
 
-	return validator( value, validationRule );
+	return validator( value );
 };

--- a/resources/ts/validation/formFieldValidationRules.ts
+++ b/resources/ts/validation/formFieldValidationRules.ts
@@ -1,0 +1,79 @@
+import { ValidationRule } from './defs';
+
+export const alphaNumeric = ( value: string ): boolean => {
+	if ( value.length === 0 ) {
+		return true;
+	}
+
+	return /^[a-zA-Z0-9]+$/.test( value );
+};
+
+export const lowerCaseOnly = ( value: string ): boolean => {
+	if ( value.length === 0 ) {
+		return true;
+	}
+
+	return value === value.toLowerCase();
+};
+
+export const upperCaseOnly = ( value: string ): boolean => {
+	if ( value.length === 0 ) {
+		return true;
+	}
+
+	return value === value.toUpperCase();
+};
+
+export const minLength = ( value: string, length: number ): boolean => {
+	return value.length >= length;
+};
+
+export const maxLength = ( value: string, length: number ): boolean => {
+	return value.length <= length;
+};
+
+export const numericString = ( value: string ): boolean => {
+	if ( value.length === 0 ) {
+		return true;
+	}
+
+	return /^[0-9]+$/.test( value );
+};
+
+export const numericStringNoLeadingZeros = ( value: string ): boolean => {
+	if ( value.length === 0 ) {
+		return true;
+	}
+
+	return /^[1-9][0-9]*$/.test( value );
+};
+
+export const validatorsMapping = {
+	alphaNumeric,
+	lowerCaseOnly,
+	upperCaseOnly,
+	minLength,
+	maxLength,
+	numericString,
+	numericStringNoLeadingZeros,
+};
+
+export const isInputValid = (
+	value: string,
+	validationRule: ValidationRule
+): boolean => {
+	const validator = validatorsMapping[ validationRule.name ];
+
+	if ( typeof validator !== 'function' ) {
+		return false;
+	}
+
+	if (
+		validationRule.name === 'minLength' ||
+		validationRule.name === 'maxLength'
+	) {
+		return validator( value, validationRule.payload.value );
+	}
+
+	return validator( value, validationRule );
+};

--- a/src/Application/FormFieldValidation/FormFieldValidationMessages.php
+++ b/src/Application/FormFieldValidation/FormFieldValidationMessages.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fau\DegreeProgram\Application\FormFieldValidation;
+
+use Fau\DegreeProgram\Application\FormFieldValidation\Rules\AlphaNumeric;
+use Fau\DegreeProgram\Application\FormFieldValidation\Rules\LowerCaseOnly;
+use Fau\DegreeProgram\Application\FormFieldValidation\Rules\MaxLength;
+use Fau\DegreeProgram\Application\FormFieldValidation\Rules\MinLength;
+use Fau\DegreeProgram\Application\FormFieldValidation\Rules\NumericString;
+use Fau\DegreeProgram\Application\FormFieldValidation\Rules\NumericStringNoLeadingZeros;
+use Fau\DegreeProgram\Application\FormFieldValidation\Rules\UpperCaseOnly;
+
+class FormFieldValidationMessages
+{
+    // phpcs:ignore Inpsyde.CodeQuality.FunctionLength.TooLong
+    public function get(FormFieldValidationRule $failedRule, string $fieldLabel): string
+    {
+        return match (true) {
+            $failedRule instanceof NumericString => sprintf(
+                // translators: %s is field label
+                __(
+                    '"%s" field must only contain numbers.',
+                    'fau-degree-program'
+                ),
+                $fieldLabel
+            ),
+            $failedRule instanceof NumericStringNoLeadingZeros => sprintf(
+                // translators: %s is field label
+                __(
+                    '"%s" field must only contain numbers, leading zeros are not allowed.',
+                    'fau-degree-program'
+                ),
+                $fieldLabel
+            ),
+            $failedRule instanceof MinLength => sprintf(
+                // translators: %1$s is field label, %2$d is minimum characters length
+                __(
+                    '"%1$s" field must be at least %2$d characters long.',
+                    'fau-degree-program'
+                ),
+                $fieldLabel,
+                (string) $failedRule->payload()['value'],
+            ),
+            $failedRule instanceof MaxLength => sprintf(
+                // translators: %1$s is field label, %2$d is maximum characters length
+                __(
+                    '"%1$s" field must be %2$d or less characters long.',
+                    'fau-degree-program'
+                ),
+                $fieldLabel,
+                (string) $failedRule->payload()['value'],
+            ),
+            $failedRule instanceof AlphaNumeric => sprintf(
+                // translators: %s is field label
+                __(
+                    '"%s" field must only contain letters and numbers.',
+                    'fau-degree-program'
+                ),
+                $fieldLabel,
+            ),
+            $failedRule instanceof LowerCaseOnly => sprintf(
+                // translators: %s is field label
+                __(
+                    '"%s" field must only contain lowercase letters.',
+                    'fau-degree-program'
+                ),
+                $fieldLabel,
+            ),
+            $failedRule instanceof UpperCaseOnly => sprintf(
+                // translators: %s is field label
+                __(
+                    '"%s" field must only contain uppercase letters.',
+                    'fau-degree-program'
+                ),
+                $fieldLabel,
+            ),
+            default => sprintf(
+                // translators: %s is field label
+                __(
+                    '"%s" field validation failed.',
+                    'fau-degree-program'
+                ),
+                $fieldLabel
+            ),
+        };
+    }
+}

--- a/src/Application/FormFieldValidation/FormFieldValidationRule.php
+++ b/src/Application/FormFieldValidation/FormFieldValidationRule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fau\DegreeProgram\Application\FormFieldValidation;
+
+interface FormFieldValidationRule
+{
+    public static function name(): string;
+    public function passes(mixed $value): bool;
+    public function payload(): array;
+}

--- a/src/Application/FormFieldValidation/FormFieldValidationRuleSet.php
+++ b/src/Application/FormFieldValidation/FormFieldValidationRuleSet.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fau\DegreeProgram\Application\FormFieldValidation;
+
+use ArrayObject;
+use Fau\DegreeProgram\Application\FormFieldValidation\Rules\AlphaNumeric;
+use Fau\DegreeProgram\Application\FormFieldValidation\Rules\LowerCaseOnly;
+use Fau\DegreeProgram\Application\FormFieldValidation\Rules\MaxLength;
+use Fau\DegreeProgram\Application\FormFieldValidation\Rules\MinLength;
+use Fau\DegreeProgram\Application\FormFieldValidation\Rules\NumericString;
+use Fau\DegreeProgram\Application\FormFieldValidation\Rules\NumericStringNoLeadingZeros;
+use Fau\DegreeProgram\Application\FormFieldValidation\Rules\UpperCaseOnly;
+use LogicException;
+
+/**
+ * @template-extends ArrayObject<string, FormFieldValidationRule>
+ */
+class FormFieldValidationRuleSet extends ArrayObject
+{
+    private function __construct()
+    {
+    }
+
+    public static function new(): self
+    {
+        return new self();
+    }
+
+    public function get(string $key): ?FormFieldValidationRule
+    {
+        return $this->offsetExists($key) ? $this->offsetGet($key) : null;
+    }
+
+    public function alphaNumeric(): self
+    {
+        $this->addRule(AlphaNumeric::name(), new AlphaNumeric());
+        return $this;
+    }
+
+    public function numericLeadingZerosAllowed(): self
+    {
+        $this->addRule(NumericString::name(), new NumericString());
+        return $this;
+    }
+
+    public function numericLeadingZerosNotAllowed(): self
+    {
+        $this->addRule(NumericStringNoLeadingZeros::name(), new NumericStringNoLeadingZeros());
+        return $this;
+    }
+
+    public function minLength(int $value): self
+    {
+        $this->addRule(MinLength::name(), new MinLength($value));
+        return $this;
+    }
+
+    public function maxLength(int $value): self
+    {
+        $this->addRule(MaxLength::name(), new MaxLength($value));
+        return $this;
+    }
+
+    public function lowerCaseOnly(): self
+    {
+        if ($this->offsetExists(LowerCaseOnly::name())) {
+            throw new LogicException('Cannot have both upper and lower case rules');
+        }
+
+        $this->addRule(LowerCaseOnly::name(), new LowerCaseOnly());
+        return $this;
+    }
+
+    public function upperCaseOnly(): self
+    {
+        if ($this->offsetExists(UpperCaseOnly::name())) {
+            throw new LogicException('Cannot have both upper and lower case rules');
+        }
+
+        $this->addRule(UpperCaseOnly::name(), new UpperCaseOnly());
+        return $this;
+    }
+
+    private function addRule(string $key, FormFieldValidationRule $rule): void
+    {
+        if (! is_null($this->get($key))) {
+            return;
+        }
+
+        $this->offsetSet($key, $rule);
+    }
+}

--- a/src/Application/FormFieldValidation/Rules/AlphaNumeric.php
+++ b/src/Application/FormFieldValidation/Rules/AlphaNumeric.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fau\DegreeProgram\Application\FormFieldValidation\Rules;
+
+use Fau\DegreeProgram\Application\FormFieldValidation\FormFieldValidationRule;
+
+class AlphaNumeric implements FormFieldValidationRule
+{
+    public function passes(mixed $value): bool
+    {
+        if ((string) $value === '') {
+            return true;
+        }
+
+        return (bool) preg_match('/^[a-zA-Z0-9]+$/', (string) $value);
+    }
+
+    public function payload(): array
+    {
+        return [];
+    }
+
+    public static function name(): string
+    {
+        return 'alphaNumeric';
+    }
+}

--- a/src/Application/FormFieldValidation/Rules/LowerCaseOnly.php
+++ b/src/Application/FormFieldValidation/Rules/LowerCaseOnly.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fau\DegreeProgram\Application\FormFieldValidation\Rules;
+
+use Fau\DegreeProgram\Application\FormFieldValidation\FormFieldValidationRule;
+
+class LowerCaseOnly implements FormFieldValidationRule
+{
+    public function passes(mixed $value): bool
+    {
+        if ((string) $value === '') {
+            return true;
+        }
+
+        return $value === strtolower((string) $value);
+    }
+
+    public function payload(): array
+    {
+        return [];
+    }
+
+    public static function name(): string
+    {
+        return 'lowerCaseOnly';
+    }
+}

--- a/src/Application/FormFieldValidation/Rules/MaxLength.php
+++ b/src/Application/FormFieldValidation/Rules/MaxLength.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fau\DegreeProgram\Application\FormFieldValidation\Rules;
+
+use Fau\DegreeProgram\Application\FormFieldValidation\FormFieldValidationRule;
+
+class MaxLength implements FormFieldValidationRule
+{
+    public function __construct(private int $value)
+    {
+    }
+
+    public function passes(mixed $value): bool
+    {
+        return strlen((string) $value) <= $this->value;
+    }
+
+    public function payload(): array
+    {
+        return [
+            'value' => $this->value,
+        ];
+    }
+
+    public static function name(): string
+    {
+        return 'maxLength';
+    }
+}

--- a/src/Application/FormFieldValidation/Rules/MinLength.php
+++ b/src/Application/FormFieldValidation/Rules/MinLength.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fau\DegreeProgram\Application\FormFieldValidation\Rules;
+
+use Fau\DegreeProgram\Application\FormFieldValidation\FormFieldValidationRule;
+
+class MinLength implements FormFieldValidationRule
+{
+    public function __construct(private int $value)
+    {
+    }
+
+    public function passes(mixed $value): bool
+    {
+        return strlen((string) $value) >= $this->value;
+    }
+
+    public function payload(): array
+    {
+        return [
+            'value' => $this->value,
+        ];
+    }
+
+    public static function name(): string
+    {
+        return 'minLength';
+    }
+}

--- a/src/Application/FormFieldValidation/Rules/NumericString.php
+++ b/src/Application/FormFieldValidation/Rules/NumericString.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fau\DegreeProgram\Application\FormFieldValidation\Rules;
+
+use Fau\DegreeProgram\Application\FormFieldValidation\FormFieldValidationRule;
+
+class NumericString implements FormFieldValidationRule
+{
+    public function passes(mixed $value): bool
+    {
+        if ((string) $value === '') {
+            return true;
+        }
+
+        return (bool) preg_match('/^[0-9]+$/', (string) $value);
+    }
+
+    public function payload(): array
+    {
+        return [];
+    }
+
+    public static function name(): string
+    {
+        return 'numericString';
+    }
+}

--- a/src/Application/FormFieldValidation/Rules/NumericStringNoLeadingZeros.php
+++ b/src/Application/FormFieldValidation/Rules/NumericStringNoLeadingZeros.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fau\DegreeProgram\Application\FormFieldValidation\Rules;
+
+use Fau\DegreeProgram\Application\FormFieldValidation\FormFieldValidationRule;
+
+class NumericStringNoLeadingZeros implements FormFieldValidationRule
+{
+    public function passes(mixed $value): bool
+    {
+        if ((string) $value === '') {
+            return true;
+        }
+
+        return (bool) preg_match('/^[1-9][0-9]*$/', (string) $value);
+    }
+
+    public function payload(): array
+    {
+        return [];
+    }
+
+    public static function name(): string
+    {
+        return 'numericStringNoLeadingZeros';
+    }
+}

--- a/src/Application/FormFieldValidation/Rules/UpperCaseOnly.php
+++ b/src/Application/FormFieldValidation/Rules/UpperCaseOnly.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fau\DegreeProgram\Application\FormFieldValidation\Rules;
+
+use Fau\DegreeProgram\Application\FormFieldValidation\FormFieldValidationRule;
+
+class UpperCaseOnly implements FormFieldValidationRule
+{
+    public function passes(mixed $value): bool
+    {
+        if ((string) $value === '') {
+            return true;
+        }
+
+        return $value === strtoupper((string) $value);
+    }
+
+    public function payload(): array
+    {
+        return [];
+    }
+
+    public static function name(): string
+    {
+        return 'upperCaseOnly';
+    }
+}

--- a/src/Infrastructure/Dashboard/TermMeta/AssetsLoader.php
+++ b/src/Infrastructure/Dashboard/TermMeta/AssetsLoader.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fau\DegreeProgram\Infrastructure\Dashboard\TermMeta;
+
+use Inpsyde\Assets\Asset;
+use Inpsyde\Assets\AssetManager;
+use Inpsyde\Assets\Loader\ArrayLoader;
+use Inpsyde\Assets\Script;
+use Inpsyde\Assets\Style;
+use Inpsyde\Modularity\Properties\PluginProperties;
+use WP_Screen;
+
+final class AssetsLoader
+{
+    public const HANDLE = 'ts/term-validation';
+
+    public function __construct(
+        private PluginProperties $pluginProperties,
+    ) {
+    }
+
+    public function load(AssetManager $assetManager): void
+    {
+        /**
+         * @var \Inpsyde\Assets\Asset[] $assets
+         */
+        $assets = (new ArrayLoader())->load([
+            [
+                'handle' => self::HANDLE,
+                'url' => (string) $this->pluginProperties->baseUrl()
+                    . 'assets/ts/term-meta-fields-validation.js',
+                'location' => Asset::BACKEND,
+                'type' => Script::class,
+                'enqueue' => fn () => !is_null($this->currentTaxonomy()),
+                'localize' => [
+                    'termMetaValidationRules' => $this->validationRules(),
+                ],
+            ],
+            [
+                'handle' => self::HANDLE,
+                'url' => (string) $this->pluginProperties->baseUrl()
+                    . 'assets/css/term-meta-fields-validation.css',
+                'location' => Asset::BACKEND,
+                'type' => Style::class,
+                'enqueue' => fn () => !is_null($this->currentTaxonomy()),
+            ],
+        ]);
+
+        $assetManager->register(...$assets);
+    }
+
+    private function validationRules(): array
+    {
+        $taxonomy = $this->currentTaxonomy();
+
+        if (is_null($taxonomy)) {
+            return [];
+        }
+
+        return (array) apply_filters(
+            "fau.degree_programs.taxonnomy_{$taxonomy}_term_metas.validation_rules",
+            [],
+        );
+    }
+
+    private function currentTaxonomy(): ?string
+    {
+        if (! function_exists('get_current_screen')) {
+            return null;
+        }
+
+        $screen = get_current_screen();
+        if (!$screen instanceof WP_Screen) {
+            return null;
+        }
+
+        return ! empty($screen->taxonomy) ? $screen->taxonomy : null;
+    }
+}

--- a/src/Infrastructure/Dashboard/TermMeta/CampoKeyMetaField.php
+++ b/src/Infrastructure/Dashboard/TermMeta/CampoKeyMetaField.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fau\DegreeProgram\Infrastructure\Dashboard\TermMeta;
+
+use Fau\DegreeProgram\Application\FormFieldValidation\FormFieldValidationRuleSet;
+use Fau\DegreeProgram\Application\FormFieldValidation\Rules;
+
+class CampoKeyMetaField extends InputTermMetaField
+{
+    public const KEY = 'uniquename';
+
+    public function __construct(
+        protected string $description,
+        private FormFieldValidationRuleSet $validationRules
+    ) {
+
+        parent::__construct(
+            self::KEY,
+            __('Campo Key', 'fau-degree-program'),
+            $description,
+            'url'
+        );
+    }
+
+    public function sanitize(mixed $value): string
+    {
+        return sanitize_text_field((string) $value);
+    }
+
+    public function metaArgs(): array
+    {
+        $schema = [
+            'type' => 'string',
+        ];
+
+        $minLength = $this->validationrules()->get(Rules\MinLength::name());
+        $maxLength = $this->validationrules()->get(Rules\MaxLength::name());
+
+        if ($minLength instanceof Rules\MinLength) {
+            $schema['minLength'] = $minLength->payload()['value'];
+        }
+
+        if ($maxLength instanceof Rules\MaxLength) {
+            $schema['maxLength'] = $maxLength->payload()['value'];
+        }
+
+        $args = parent::metaArgs();
+        $args['show_in_rest'] = [
+            'schema' => $schema,
+        ];
+
+        return $args;
+    }
+
+    public function validationRules(): FormFieldValidationRuleSet
+    {
+        return $this->validationRules;
+    }
+}

--- a/src/Infrastructure/Dashboard/TermMeta/EnglishNameTermMetaField.php
+++ b/src/Infrastructure/Dashboard/TermMeta/EnglishNameTermMetaField.php
@@ -8,6 +8,8 @@ use Fau\DegreeProgram\Common\Infrastructure\Repository\BilingualRepository;
 
 final class EnglishNameTermMetaField extends InputTermMetaField
 {
+    use NoValidationTermMetaFieldTrait;
+
     public function __construct()
     {
 

--- a/src/Infrastructure/Dashboard/TermMeta/InputTermMetaField.php
+++ b/src/Infrastructure/Dashboard/TermMeta/InputTermMetaField.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Fau\DegreeProgram\Infrastructure\Dashboard\TermMeta;
 
+use Fau\DegreeProgram\Application\FormFieldValidation\Rules;
+
 class InputTermMetaField implements TermMetaField
 {
+    use NoValidationTermMetaFieldTrait;
+
     public function __construct(
         private string $key,
-        private string $title,
-        private string $description = '',
+        protected string $title,
+        protected string $description = '',
         private string $type = 'text',
     ) {
     }
@@ -17,6 +21,11 @@ class InputTermMetaField implements TermMetaField
     public function key(): string
     {
         return $this->key;
+    }
+
+    public function title(): string
+    {
+        return $this->title;
     }
 
     public function sanitize(mixed $value): string
@@ -31,13 +40,19 @@ class InputTermMetaField implements TermMetaField
 
     public function templateData(mixed $value): array
     {
+        /** @var ?Rules\MinLength $minLength */
+        $minLength = $this->validationrules()->get(Rules\MinLength::name());
+        /** @var ?Rules\MaxLength $maxLength */
+        $maxLength = $this->validationrules()->get(Rules\MaxLength::name());
+
         return [
             'key' => $this->key,
             'value' => (string) $value,
-            'title' => $this->title,
+            'title' => $this->title(),
             'description' => $this->description,
             'type' => $this->type,
-
+            'minLength' => $minLength?->payload()['value'] ?? null,
+            'maxLength' => $maxLength?->payload()['value'] ?? null,
         ];
     }
 

--- a/src/Infrastructure/Dashboard/TermMeta/NoValidationTermMetaFieldTrait.php
+++ b/src/Infrastructure/Dashboard/TermMeta/NoValidationTermMetaFieldTrait.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fau\DegreeProgram\Infrastructure\Dashboard\TermMeta;
+
+use Fau\DegreeProgram\Application\FormFieldValidation\FormFieldValidationRuleSet;
+
+trait NoValidationTermMetaFieldTrait
+{
+    // Empty validation rule set.
+    public function validationRules(): FormFieldValidationRuleSet
+    {
+        return FormFieldValidationRuleSet::new();
+    }
+}

--- a/src/Infrastructure/Dashboard/TermMeta/TermMetaField.php
+++ b/src/Infrastructure/Dashboard/TermMeta/TermMetaField.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace Fau\DegreeProgram\Infrastructure\Dashboard\TermMeta;
 
+use Fau\DegreeProgram\Application\FormFieldValidation\FormFieldValidationRuleSet;
+
 interface TermMetaField
 {
     public function key(): string;
+    public function title(): string;
     public function sanitize(mixed $value): mixed;
 
     public function templateName(): string;
     public function templateData(mixed $value): array;
+    public function validationRules(): FormFieldValidationRuleSet;
 
     /**
      * @see register_meta

--- a/src/Infrastructure/Dashboard/TermMeta/TermMetaRegistrar.php
+++ b/src/Infrastructure/Dashboard/TermMeta/TermMetaRegistrar.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Fau\DegreeProgram\Infrastructure\Dashboard\TermMeta;
 
+use Fau\DegreeProgram\Application\FormFieldValidation\FormFieldValidationMessages;
 use Fau\DegreeProgram\Common\Infrastructure\TemplateRenderer\Renderer;
+use WP_Error;
 use WP_Term;
 
 final class TermMetaRegistrar
@@ -12,6 +14,7 @@ final class TermMetaRegistrar
     public function __construct(
         private Renderer $termMetaFieldRenderer,
         private TermMetaRepository $termMetaRepository,
+        private FormFieldValidationMessages $validationMessages,
     ) {
     }
 
@@ -31,6 +34,11 @@ final class TermMetaRegistrar
                 $taxonomy,
                 $field->key(),
                 $field->metaArgs()
+            );
+
+            add_filter(
+                "fau.degree_programs.taxonnomy_{$taxonomy}_term_metas.validation_rules",
+                fn (array $rules) => $this->addJavascriptFieldValidationRules($rules, $field),
             );
         }
 
@@ -64,21 +72,83 @@ final class TermMetaRegistrar
 
         add_action("edit_{$taxonomy}", $updateCallback);
         add_action("create_{$taxonomy}", $updateCallback);
+        add_filter('pre_insert_term', $this->buildValidationCallback(...$termMetaFields));
+    }
+
+    // phpcs:ignore Inpsyde.CodeQuality.NestingLevel.High
+    private function buildValidationCallback(TermMetaField ...$termMetaFields): callable
+    {
+        return function (mixed $term) use ($termMetaFields): mixed {
+            if ($term instanceof WP_Error) {
+                return $term;
+            }
+
+            $error = null;
+
+            foreach ($termMetaFields as $termMetaField) {
+                $postedValue = filter_input(
+                    INPUT_POST,
+                    $termMetaField->key(),
+                    FILTER_SANITIZE_SPECIAL_CHARS
+                );
+
+                $error = $this->checkForErrors($termMetaField, $postedValue);
+
+                if ($error instanceof WP_Error) {
+                    return $error;
+                }
+            }
+
+            return $term;
+        };
+    }
+
+    private function checkForErrors(TermMetaField $termMetaField, mixed $value): ?WP_Error
+    {
+        foreach ($termMetaField->validationRules() as $validationRule) {
+            if ($validationRule->passes($value)) {
+                continue;
+            }
+
+            return new WP_Error(
+                'invalid_term_meta',
+                $this->validationMessages->get($validationRule, $termMetaField->title()),
+            );
+        }
+
+        return null;
     }
 
     private function buildUpdateCallback(TermMetaField ...$termMetaFields): callable
     {
         return function (int $termId) use ($termMetaFields): void {
             foreach ($termMetaFields as $termMetaField) {
-                // phpcs:ignore WordPressVIPMinimum.Security.PHPFilterFunctions.MissingThirdParameter
                 $postedValue = filter_input(
                     INPUT_POST,
                     $termMetaField->key(),
+                    FILTER_SANITIZE_SPECIAL_CHARS
                 );
 
                 $sanitizedValue = $termMetaField->sanitize($postedValue);
                 $this->termMetaRepository->update($termId, $termMetaField->key(), $sanitizedValue);
             }
         };
+    }
+
+    private function addJavascriptFieldValidationRules(array $rules, TermMetaField $field): array
+    {
+        $result = [];
+
+        foreach ($field->validationRules() as $validationRule) {
+            $result[] = (object) [
+                'name' => $validationRule::name(),
+                'payload' => $validationRule->payload(),
+                'errorMessage' => $this->validationMessages->get($validationRule, $field->title()),
+            ];
+        }
+
+        $rules[$field->key()] = $result;
+
+        return $rules;
     }
 }

--- a/templates/term-meta/partials/input.php
+++ b/templates/term-meta/partials/input.php
@@ -3,14 +3,24 @@
 declare(strict_types=1);
 
 /**
- * @var array{key: string, value: string, title: string, description: string, type: string} $data
+ * @var array{
+ *     key: string,
+ *     description: string,
+ *     minLength: ?int,
+ *     maxLength: ?int,
+ *     title: string,
+ *     type: string,
+ *     value: string
+ * } $data
  */
 
 [
     'key' => $key,
-    'value' => $value,
     'description' => $description,
+    'minLength' => $minLength,
+    'maxLength' => $maxLength,
     'type' => $type,
+    'value' => $value,
 ] = $data;
 
 ?>
@@ -23,7 +33,13 @@ declare(strict_types=1);
        size="40"
        <?php if ($description) : ?>
            aria-describedby="<?= esc_attr($key) ?>-description"
-       <?php endif; ?>
+       <?php endif ?>
+       <?php if (! is_null($minLength)) : ?>
+           minlength="<?= esc_attr((string) $minLength) ?>"
+       <?php endif ?>
+       <?php if (! is_null($maxLength)) : ?>
+           maxlength="<?= esc_attr((string) $maxLength) ?>"
+       <?php endif ?>
 />
 <?php if ($description) : ?>
     <p class="description" id="<?= esc_attr($key) ?>-description">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,8 @@ module.exports = {
         'css/degree-program-list-table': './resources/scss/degree-program-list-table.scss',
         'ts/degree-program-editor': './resources/ts/degree-program-editor.ts',
         'ts/degree-program-list-table': './resources/ts/degree-program-list-table.ts',
+        'ts/term-meta-fields-validation': './resources/ts/term-meta-fields-validation.ts',
+        'css/term-meta-fields-validation': './resources/scss/term-meta-fields-validation.scss',
     },
     output: {
         publicPath: './',


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-411


**What is the new behavior (if this is a feature change)?**
- Added campo-key field for the following taxonomies: `abschluss`, `area_of_study`, `faechergruppe`, `standort`
- Add generic form field validation rules.
- Add validation error messages both on backend and javascript.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
