### PR TITLE
[FAU-411] Add campo-key field / Add form fields validation rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support WordPress "Quote" block in content fields.
-- Campo-Key term meta field.
-- Term meta fields validation rules.
+- "Campo-Key" term meta field.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support WordPress "Quote" block in content fields.
+- Campo-Key term meta field.
+- Term meta fields validation rules.
 
 ### Changed
 
-- Make "Duration of studies in semester" a single line input. 
+- Make "Duration of studies in semester" a single line input.
 
 ## [1.2.7] - 2023-11-23
 

--- a/resources/ts/components/ContentField/styles.scss
+++ b/resources/ts/components/ContentField/styles.scss
@@ -1,5 +1,7 @@
-// Unfortunately, there is no way to filter or adjust the core blocks toolbar.
-// Hiding the block toolbar items is fragile, so it is merely a UX improvement,
+// Unfortunately, there is no way to filter
+// or adjust the core blocks toolbar.
+// Hiding the block toolbar items is fragile,
+// so it is merely a UX improvement,
 // with the actual sanitization happening server-side.
 
 // Hide H1, H2 and H6 Heading level toolbar buttons

--- a/resources/ts/term-meta-fields-validation.ts
+++ b/resources/ts/term-meta-fields-validation.ts
@@ -1,0 +1,34 @@
+import domReady from '@wordpress/dom-ready';
+
+const TERM_EDIT_FORM_SELECTOR = '#addtag, #edittag';
+
+domReady( () => {
+	const form = document.querySelector< HTMLFormElement >(
+		TERM_EDIT_FORM_SELECTOR
+	);
+	const submitButton = form?.querySelector< HTMLButtonElement >(
+		"input[type='submit']"
+	);
+
+	if ( ! form || ! submitButton ) {
+		return;
+	}
+
+	form.querySelectorAll< HTMLInputElement >( '.form-field input' ).forEach(
+		( input ) => {
+			input.addEventListener( 'input', () => {
+				if ( form.checkValidity() ) {
+					submitButton.disabled = false;
+					return;
+				}
+
+				if ( input.checkValidity() ) {
+					return;
+				}
+
+				submitButton.disabled = true;
+				form.reportValidity();
+			} );
+		}
+	);
+} );

--- a/src/Infrastructure/Dashboard/TermMeta/AssetsLoader.php
+++ b/src/Infrastructure/Dashboard/TermMeta/AssetsLoader.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fau\DegreeProgram\Infrastructure\Dashboard\TermMeta;
+
+use Inpsyde\Assets\Asset;
+use Inpsyde\Assets\AssetManager;
+use Inpsyde\Assets\Loader\ArrayLoader;
+use Inpsyde\Assets\Script;
+use Inpsyde\Modularity\Properties\PluginProperties;
+use WP_Screen;
+
+final class AssetsLoader
+{
+    public const HANDLE = 'ts/term-validation';
+
+    public function __construct(
+        private PluginProperties $pluginProperties,
+    ) {
+    }
+
+    public function load(AssetManager $assetManager): void
+    {
+        /**
+         * @var \Inpsyde\Assets\Asset[] $assets
+         */
+        $assets = (new ArrayLoader())->load([
+            [
+                'handle' => self::HANDLE,
+                'url' => (string) $this->pluginProperties->baseUrl()
+                    . 'assets/ts/term-meta-fields-validation.js',
+                'location' => Asset::BACKEND,
+                'type' => Script::class,
+                'enqueue' => fn () => $this->isTermTaxonomyEditContext(),
+            ],
+        ]);
+
+        $assetManager->register(...$assets);
+    }
+
+    private function isTermTaxonomyEditContext(): bool
+    {
+        if (! function_exists('get_current_screen')) {
+            return false;
+        }
+
+        $screen = get_current_screen();
+        if (!$screen instanceof WP_Screen) {
+            return false;
+        }
+
+        return ! empty($screen->taxonomy);
+    }
+}

--- a/src/Infrastructure/Dashboard/TermMeta/CampoKeyTermMetaField.php
+++ b/src/Infrastructure/Dashboard/TermMeta/CampoKeyTermMetaField.php
@@ -9,67 +9,15 @@ class CampoKeyTermMetaField extends InputTermMetaField
     public const KEY = 'uniquename';
 
     public function __construct(
-        protected string $description,
-        private ?TermMetaFieldValidationPattern $validationPattern = null,
+        string $description,
+        TermMetaFieldValidationPattern $validationPattern = null,
     ) {
 
         parent::__construct(
             self::KEY,
             __('Campo Key', 'fau-degree-program'),
             $description,
-            'text'
+            validationPattern: $validationPattern,
         );
-    }
-
-    public function title(): string
-    {
-        return $this->title;
-    }
-
-    public function sanitize(mixed $value): string
-    {
-        return sanitize_text_field((string) $value);
-    }
-
-    public function templateName(): string
-    {
-        return 'input-term';
-    }
-
-    public function validationPattern(): ?TermMetaFieldValidationPattern
-    {
-        return $this->validationPattern;
-    }
-
-    public function templateData(mixed $value): array
-    {
-        return [
-            'key' => $this->key(),
-            'value' => (string) $value,
-            'title' => $this->title,
-            'description' => $this->description,
-            'type' => $this->type,
-            'validationPattern' => $this->validationPattern,
-        ];
-    }
-
-    public function metaArgs(): array
-    {
-        $schema = ['type' => 'string'];
-
-        if (! is_null($this->validationPattern)) {
-            $schema['pattern'] = $this->validationPattern->pattern();
-        }
-
-        return [
-            'type' => 'string',
-            'description' => $this->description,
-            'single' => true,
-            'default' => '',
-            'sanitize_callback' => [$this, 'sanitize'],
-            'show_in_rest' => [
-                'schema' => $schema,
-            ],
-        ];
     }
 }

--- a/src/Infrastructure/Dashboard/TermMeta/CampoKeyTermMetaField.php
+++ b/src/Infrastructure/Dashboard/TermMeta/CampoKeyTermMetaField.php
@@ -10,7 +10,7 @@ class CampoKeyTermMetaField extends InputTermMetaField
 
     public function __construct(
         protected string $description,
-        private string $validationPattern,
+        private ?TermMetaFieldValidationPattern $validationPattern = null,
     ) {
         parent::__construct(
             self::KEY,
@@ -35,7 +35,7 @@ class CampoKeyTermMetaField extends InputTermMetaField
         return 'input-term';
     }
 
-    public function validationPattern(): string
+    public function validationPattern(): ?TermMetaFieldValidationPattern
     {
         return $this->validationPattern;
     }
@@ -48,19 +48,27 @@ class CampoKeyTermMetaField extends InputTermMetaField
             'title' => $this->title,
             'description' => $this->description,
             'type' => $this->type,
-            'pattern' => $this->validationPattern,
+            'validationPattern' => $this->validationPattern,
         ];
     }
 
     public function metaArgs(): array
     {
+        $schema = ['type' =>'string'];
+
+        if (! is_null($this->validationPattern)) {
+            $schema['pattern'] = $this->validationPattern->pattern();
+        }
+
         return [
             'type' => 'string',
             'description' => $this->description,
             'single' => true,
             'default' => '',
             'sanitize_callback' => [$this, 'sanitize'],
-            'show_in_rest' => true,
+            'show_in_rest' => [
+                'schema' => $schema,
+            ],
         ];
     }
 }

--- a/src/Infrastructure/Dashboard/TermMeta/CampoKeyTermMetaField.php
+++ b/src/Infrastructure/Dashboard/TermMeta/CampoKeyTermMetaField.php
@@ -4,19 +4,20 @@ declare(strict_types=1);
 
 namespace Fau\DegreeProgram\Infrastructure\Dashboard\TermMeta;
 
-class InputTermMetaField implements TermMetaField
+class CampoKeyTermMetaField extends InputTermMetaField
 {
-    public function __construct(
-        protected string $key,
-        protected string $title,
-        protected string $description = '',
-        protected string $type = 'text',
-    ) {
-    }
+    public const KEY = 'uniquename';
 
-    public function key(): string
-    {
-        return $this->key;
+    public function __construct(
+        protected string $description,
+        private string $validationPattern,
+    ) {
+        parent::__construct(
+            self::KEY,
+            __('Campo Key', 'fau-degree-program'),
+            $description,
+            'text'
+        );
     }
 
     public function title(): string
@@ -34,15 +35,20 @@ class InputTermMetaField implements TermMetaField
         return 'input-term';
     }
 
+    public function validationPattern(): string
+    {
+        return $this->validationPattern;
+    }
+
     public function templateData(mixed $value): array
     {
         return [
-            'key' => $this->key,
+            'key' => $this->key(),
             'value' => (string) $value,
             'title' => $this->title,
             'description' => $this->description,
             'type' => $this->type,
-
+            'pattern' => $this->validationPattern,
         ];
     }
 

--- a/src/Infrastructure/Dashboard/TermMeta/CampoKeyTermMetaField.php
+++ b/src/Infrastructure/Dashboard/TermMeta/CampoKeyTermMetaField.php
@@ -12,6 +12,7 @@ class CampoKeyTermMetaField extends InputTermMetaField
         protected string $description,
         private ?TermMetaFieldValidationPattern $validationPattern = null,
     ) {
+
         parent::__construct(
             self::KEY,
             __('Campo Key', 'fau-degree-program'),
@@ -54,7 +55,7 @@ class CampoKeyTermMetaField extends InputTermMetaField
 
     public function metaArgs(): array
     {
-        $schema = ['type' =>'string'];
+        $schema = ['type' => 'string'];
 
         if (! is_null($this->validationPattern)) {
             $schema['pattern'] = $this->validationPattern->pattern();

--- a/src/Infrastructure/Dashboard/TermMeta/InputTermMetaField.php
+++ b/src/Infrastructure/Dashboard/TermMeta/InputTermMetaField.php
@@ -7,10 +7,11 @@ namespace Fau\DegreeProgram\Infrastructure\Dashboard\TermMeta;
 class InputTermMetaField implements TermMetaField
 {
     public function __construct(
-        protected string $key,
-        protected string $title,
-        protected string $description = '',
-        protected string $type = 'text',
+        private string $key,
+        private string $title,
+        private string $description = '',
+        private string $type = 'text',
+        private ?TermMetaFieldValidationPattern $validationPattern = null,
     ) {
     }
 
@@ -36,6 +37,17 @@ class InputTermMetaField implements TermMetaField
 
     public function templateData(mixed $value): array
     {
+        $showInRest = true;
+
+        if (! is_null($this->validationPattern)) {
+            $showInRest = [
+                'schema' => [
+                    'type' => 'string',
+                    'pattern' => $this->validationPattern->pattern(),
+                ],
+            ];
+        }
+
         return [
             'key' => $this->key,
             'value' => (string) $value,
@@ -43,6 +55,7 @@ class InputTermMetaField implements TermMetaField
             'description' => $this->description,
             'type' => $this->type,
             'validationPattern' => $this->validationPattern(),
+            'show_in_rest' => $showInRest,
         ];
     }
 
@@ -60,6 +73,6 @@ class InputTermMetaField implements TermMetaField
 
     public function validationPattern(): ?TermMetaFieldValidationPattern
     {
-        return null;
+        return $this->validationPattern;
     }
 }

--- a/src/Infrastructure/Dashboard/TermMeta/InputTermMetaField.php
+++ b/src/Infrastructure/Dashboard/TermMeta/InputTermMetaField.php
@@ -42,7 +42,7 @@ class InputTermMetaField implements TermMetaField
             'title' => $this->title,
             'description' => $this->description,
             'type' => $this->type,
-
+            'validationPattern' => $this->validationPattern(),
         ];
     }
 
@@ -56,5 +56,10 @@ class InputTermMetaField implements TermMetaField
             'sanitize_callback' => [$this, 'sanitize'],
             'show_in_rest' => true,
         ];
+    }
+
+    public function validationPattern(): ?TermMetaFieldValidationPattern
+    {
+        return null;
     }
 }

--- a/src/Infrastructure/Dashboard/TermMeta/TermMetaField.php
+++ b/src/Infrastructure/Dashboard/TermMeta/TermMetaField.php
@@ -7,6 +7,7 @@ namespace Fau\DegreeProgram\Infrastructure\Dashboard\TermMeta;
 interface TermMetaField
 {
     public function key(): string;
+    public function title(): string;
     public function sanitize(mixed $value): mixed;
 
     public function templateName(): string;

--- a/src/Infrastructure/Dashboard/TermMeta/TermMetaField.php
+++ b/src/Infrastructure/Dashboard/TermMeta/TermMetaField.php
@@ -12,6 +12,7 @@ interface TermMetaField
 
     public function templateName(): string;
     public function templateData(mixed $value): array;
+    public function validationPattern(): ?TermMetaFieldValidationPattern;
 
     /**
      * @see register_meta

--- a/src/Infrastructure/Dashboard/TermMeta/TermMetaFieldValidationPattern.php
+++ b/src/Infrastructure/Dashboard/TermMeta/TermMetaFieldValidationPattern.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fau\DegreeProgram\Infrastructure\Dashboard\TermMeta;
+
+class TermMetaFieldValidationPattern
+{
+    /**
+     * @param non-empty-string $pattern regex pattern without delimiters
+     * @param string $expectedPatternMessage message to display as the expected pattern
+     */
+    public function __construct(
+        private string $pattern,
+        private string $expectedPatternMessage = '',
+    ) {
+    }
+
+    public function matches(string $value): bool
+    {
+        return (bool) preg_match(
+            '/' . $this->pattern() . '/',
+            $value
+        );
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function pattern(): string
+    {
+        return $this->pattern;
+    }
+
+    public function expectedPatternMessage(): string
+    {
+        return $this->expectedPatternMessage;
+    }
+}

--- a/src/Infrastructure/Dashboard/TermMeta/TermMetaFieldsValidator.php
+++ b/src/Infrastructure/Dashboard/TermMeta/TermMetaFieldsValidator.php
@@ -39,7 +39,7 @@ final class TermMetaFieldsValidator
                     sprintf(
                         // translators: %1$s: field title. %2$s: expected pattern description.
                         __(
-                            'The value of the field %1$s is invalid. expected value: %2$s',
+                            'The value of the field &#8220;%1$s&#8221; is invalid. expected value: %2$s',
                             'fau-degree-program'
                         ),
                         $termMetaField->title(),

--- a/src/Infrastructure/Dashboard/TermMeta/TermMetaFieldsValidator.php
+++ b/src/Infrastructure/Dashboard/TermMeta/TermMetaFieldsValidator.php
@@ -20,10 +20,10 @@ final class TermMetaFieldsValidator
                 continue;
             }
 
-            // phpcs:ignore WordPressVIPMinimum.Security.PHPFilterFunctions.MissingThirdParameter
             $postedValue = filter_input(
                 INPUT_POST,
                 $termMetaField->key(),
+                FILTER_SANITIZE_SPECIAL_CHARS
             );
 
             $sanitizedValue = (string) $termMetaField->sanitize($postedValue);

--- a/src/Infrastructure/Dashboard/TermMeta/TermMetaFieldsValidator.php
+++ b/src/Infrastructure/Dashboard/TermMeta/TermMetaFieldsValidator.php
@@ -15,8 +15,8 @@ final class TermMetaFieldsValidator
         }
 
         foreach ($termMetaFields as $termMetaField) {
-            // Only campo key field supports validation.
-            if (! $termMetaField instanceof CampoKeyTermMetaField) {
+            $validationPattern = $termMetaField->validationPattern();
+            if (is_null($validationPattern)) {
                 continue;
             }
 
@@ -26,15 +26,10 @@ final class TermMetaFieldsValidator
                 $termMetaField->key(),
             );
 
-            $sanitizedValue = $termMetaField->sanitize($postedValue);
+            $sanitizedValue = (string) $termMetaField->sanitize($postedValue);
 
             // Skip validation if field is empty.
             if ($sanitizedValue === '') {
-                continue;
-            }
-
-            $validationPattern = $termMetaField->validationPattern();
-            if (is_null($validationPattern)) {
                 continue;
             }
 

--- a/src/Infrastructure/Dashboard/TermMeta/TermMetaFieldsValidator.php
+++ b/src/Infrastructure/Dashboard/TermMeta/TermMetaFieldsValidator.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fau\DegreeProgram\Infrastructure\Dashboard\TermMeta;
+
+use WP_Error;
+
+final class TermMetaFieldsValidator
+{
+    public function validate(TermMetaField ...$termMetaFields): ?WP_Error
+    {
+        if (! $this->isTermEditingContext()) {
+            return null;
+        }
+
+        foreach ($termMetaFields as $termMetaField) {
+            // Only campo key field supports validation.
+            if (! $termMetaField instanceof CampoKeyTermMetaField) {
+                continue;
+            }
+
+            // phpcs:ignore WordPressVIPMinimum.Security.PHPFilterFunctions.MissingThirdParameter
+            $postedValue = filter_input(
+                INPUT_POST,
+                $termMetaField->key(),
+            );
+
+            $sanitizedValue = $termMetaField->sanitize($postedValue);
+
+            // Skip validation if field is empty.
+            if ($sanitizedValue === '') {
+                continue;
+            }
+
+            $validationPattern = $termMetaField->validationPattern();
+            if (is_null($validationPattern)) {
+                continue;
+            }
+
+            if (! $validationPattern->matches($sanitizedValue)) {
+                return new WP_Error(
+                    'invalid_term_meta',
+                    sprintf(
+                        __(
+                            'The value of the field %s is invalid. expected value: %s',
+                            'fau-degree-program'
+                        ),
+                        $termMetaField->title(),
+                        $validationPattern->expectedPatternMessage(),
+                    )
+                );
+            }
+        }
+
+        return null;
+    }
+
+    private function isTermEditingContext(): bool
+    {
+        $action = filter_input(INPUT_POST, 'action', FILTER_SANITIZE_SPECIAL_CHARS);
+        return $action === 'editedtag' || $action === 'add-tag';
+    }
+}

--- a/src/Infrastructure/Dashboard/TermMeta/TermMetaFieldsValidator.php
+++ b/src/Infrastructure/Dashboard/TermMeta/TermMetaFieldsValidator.php
@@ -42,8 +42,9 @@ final class TermMetaFieldsValidator
                 return new WP_Error(
                     'invalid_term_meta',
                     sprintf(
+                        // translators: %1$s: field title. %2$s: expected pattern description.
                         __(
-                            'The value of the field %s is invalid. expected value: %s',
+                            'The value of the field %1$s is invalid. expected value: %2$s',
                             'fau-degree-program'
                         ),
                         $termMetaField->title(),

--- a/src/Infrastructure/Dashboard/TermMeta/TermMetaModule.php
+++ b/src/Infrastructure/Dashboard/TermMeta/TermMetaModule.php
@@ -47,9 +47,11 @@ final class TermMetaModule implements ServiceModule, ExecutableModule
                 )
             ),
             TermMetaRepository::class => fn() => new TermMetaRepository(),
+            TermMetaFieldsValidator::class => fn() => new TermMetaFieldsValidator(),
             TermMetaRegistrar::class => static fn(ContainerInterface $container): TermMetaRegistrar => new TermMetaRegistrar(
                 termMetaFieldRenderer: $container->get(TermMetaModule::TERM_META_FIELD_RENDERER),
                 termMetaRepository: $container->get(TermMetaRepository::class),
+                validator: $container->get(TermMetaFieldsValidator::class),
             ),
         ];
     }
@@ -68,7 +70,10 @@ final class TermMetaModule implements ServiceModule, ExecutableModule
                     'Please enter only numbers, maximum 3 digits, leading zeros are allowed.',
                     'fau-degree-program'
                 ),
-                '/^[0-9]{1,3}$/',
+                new TermMetaFieldValidationPattern(
+                    '^(?:[0-9]{1,3}|$)$',
+                    __('1-3 digits number', 'fau-degree-program'),
+                ),
             )),
             ...(new MultilingualLinkTermMetaFields())->getArrayCopy(),
         );
@@ -115,7 +120,10 @@ final class TermMetaModule implements ServiceModule, ExecutableModule
                     'Please enter uppercase alphanumeric characters and maximum 3 characters.',
                     'fau-degree-program'
                 ),
-                '/^[A-Z0-9]{1,3}$/',
+                new TermMetaFieldValidationPattern(
+                    '^(?:[A-Z0-9]{1,3}|$)$',
+                    __('1-3 upper case letters or numbers', 'fau-degree-program'),
+                ),
             )),
             new EnglishNameTermMetaField(),
         );
@@ -126,7 +134,10 @@ final class TermMetaModule implements ServiceModule, ExecutableModule
                     'Please enter only numbers, maximum 3 digits, leading zeros are allowed.',
                     'fau-degree-program'
                 ),
-                '/^[0-9]{1,3}$/',
+                new TermMetaFieldValidationPattern(
+                    '^(?:[0-9]{1,3}|$)$',
+                    __('1-3 digits number', 'fau-degree-program'),
+                ),
             )),
             new EnglishNameTermMetaField(),
         );
@@ -161,7 +172,10 @@ final class TermMetaModule implements ServiceModule, ExecutableModule
                     'Please enter lowercase alphanumeric characters and maximum 3 characters.',
                     'fau-degree-program'
                 ),
-                '/^[a-z0-9]{1,3}$/',
+                new TermMetaFieldValidationPattern(
+                    '^(?:[a-z0-9]{1,3}|$)$',
+                    __('1-3 lower case letters or numbers', 'fau-degree-program'),
+                ),
             )),
             new InputTermMetaField(
                 Degree::ABBREVIATION,

--- a/src/Infrastructure/Dashboard/TermMeta/TermMetaModule.php
+++ b/src/Infrastructure/Dashboard/TermMeta/TermMetaModule.php
@@ -71,12 +71,12 @@ final class TermMetaModule implements ServiceModule, ExecutableModule
             AreaOfStudyTaxonomy::KEY,
             (new CampoKeyTermMetaField(
                 __(
-                    'Please enter only numbers, maximum 3 digits, leading zeros are allowed.',
+                    'Up to 3 digits, no letters. Leading zeros are allowed.',
                     'fau-degree-program'
                 ),
                 new TermMetaFieldValidationPattern(
                     '^(?:[0-9]{1,3}|$)$',
-                    __('1-3 digits number', 'fau-degree-program'),
+                    __('1 to 3 digits', 'fau-degree-program'),
                 ),
             )),
             ...(new MultilingualLinkTermMetaFields())->getArrayCopy(),
@@ -121,12 +121,12 @@ final class TermMetaModule implements ServiceModule, ExecutableModule
             StudyLocationTaxonomy::KEY,
             (new CampoKeyTermMetaField(
                 __(
-                    'Please enter uppercase alphanumeric characters and maximum 3 characters.',
+                    'Up to 3 uppercase alphanumeric characters.',
                     'fau-degree-program'
                 ),
                 new TermMetaFieldValidationPattern(
                     '^(?:[A-Z0-9]{1,3}|$)$',
-                    __('1-3 upper case letters or numbers', 'fau-degree-program'),
+                    __('1 to 3 uppercase letters or digits', 'fau-degree-program'),
                 ),
             )),
             new EnglishNameTermMetaField(),
@@ -135,12 +135,12 @@ final class TermMetaModule implements ServiceModule, ExecutableModule
             SubjectGroupTaxonomy::KEY,
             (new CampoKeyTermMetaField(
                 __(
-                    'Please enter only numbers, maximum 3 digits, leading zeros are allowed.',
+                    'Up to 3 digits, no letters. Leading zeros are allowed.',
                     'fau-degree-program'
                 ),
                 new TermMetaFieldValidationPattern(
                     '^(?:[0-9]{1,3}|$)$',
-                    __('1-3 digits number', 'fau-degree-program'),
+                    __('1 to 3 digits', 'fau-degree-program'),
                 ),
             )),
             new EnglishNameTermMetaField(),
@@ -178,12 +178,12 @@ final class TermMetaModule implements ServiceModule, ExecutableModule
         return [
             (new CampoKeyTermMetaField(
                 __(
-                    'Please enter lowercase alphanumeric characters and maximum 3 characters.',
+                    'Up to 3 lowercase alphanumeric characters.',
                     'fau-degree-program'
                 ),
                 new TermMetaFieldValidationPattern(
                     '^(?:[a-z0-9]{1,3}|$)$',
-                    __('1-3 lower case letters or numbers', 'fau-degree-program'),
+                    __('1 to 3 lowercase letters or digits, 'fau-degree-program'),
                 ),
             )),
             new InputTermMetaField(

--- a/src/Infrastructure/Dashboard/TermMeta/TermMetaModule.php
+++ b/src/Infrastructure/Dashboard/TermMeta/TermMetaModule.php
@@ -183,7 +183,7 @@ final class TermMetaModule implements ServiceModule, ExecutableModule
                 ),
                 new TermMetaFieldValidationPattern(
                     '^(?:[a-z0-9]{1,3}|$)$',
-                    __('1 to 3 lowercase letters or digits, 'fau-degree-program'),
+                    __('1 to 3 lowercase letters or digits', 'fau-degree-program'),
                 ),
             )),
             new InputTermMetaField(

--- a/src/Infrastructure/Dashboard/TermMeta/TermMetaModule.php
+++ b/src/Infrastructure/Dashboard/TermMeta/TermMetaModule.php
@@ -26,6 +26,7 @@ use Fau\DegreeProgram\Common\Infrastructure\Repository\BilingualRepository;
 use Fau\DegreeProgram\Common\Infrastructure\TemplateRenderer\DirectoryLocator;
 use Fau\DegreeProgram\Common\Infrastructure\TemplateRenderer\Renderer;
 use Fau\DegreeProgram\Common\Infrastructure\TemplateRenderer\TemplateRenderer;
+use Inpsyde\Assets\AssetManager;
 use Inpsyde\Modularity\Module\ExecutableModule;
 use Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use Inpsyde\Modularity\Module\ServiceModule;
@@ -41,6 +42,9 @@ final class TermMetaModule implements ServiceModule, ExecutableModule
     public function services(): array
     {
         return [
+            AssetsLoader::class => static fn(ContainerInterface $container) => new AssetsLoader(
+                $container->get(Package::PROPERTIES),
+            ),
             self::TERM_META_FIELD_RENDERER => static fn(ContainerInterface $container): Renderer => TemplateRenderer::new(
                 DirectoryLocator::new(
                     $container->get(Package::PROPERTIES)->basePath() . '/templates/term-meta'
@@ -156,6 +160,12 @@ final class TermMetaModule implements ServiceModule, ExecutableModule
         $termMetaRegistrar->register(
             ApplyNowLinkTaxonomy::KEY,
             ...(new MultilingualLinkTermMetaFields())->getArrayCopy(),
+        );
+
+
+        add_action(
+            AssetManager::ACTION_SETUP,
+            [$container->get(AssetsLoader::class), 'load']
         );
 
         return true;

--- a/src/Infrastructure/Dashboard/TermMeta/TermMetaModule.php
+++ b/src/Infrastructure/Dashboard/TermMeta/TermMetaModule.php
@@ -63,6 +63,13 @@ final class TermMetaModule implements ServiceModule, ExecutableModule
 
         $termMetaRegistrar->register(
             AreaOfStudyTaxonomy::KEY,
+            (new CampoKeyTermMetaField(
+                __(
+                    'Please enter only numbers, maximum 3 digits, leading zeros are allowed.',
+                    'fau-degree-program'
+                ),
+                '/^[0-9]{1,3}$/',
+            )),
             ...(new MultilingualLinkTermMetaFields())->getArrayCopy(),
         );
         $termMetaRegistrar->register(
@@ -103,10 +110,24 @@ final class TermMetaModule implements ServiceModule, ExecutableModule
         );
         $termMetaRegistrar->register(
             StudyLocationTaxonomy::KEY,
+            (new CampoKeyTermMetaField(
+                __(
+                    'Please enter uppercase alphanumeric characters and maximum 3 characters.',
+                    'fau-degree-program'
+                ),
+                '/^[A-Z0-9]{1,3}$/',
+            )),
             new EnglishNameTermMetaField(),
         );
         $termMetaRegistrar->register(
             SubjectGroupTaxonomy::KEY,
+            (new CampoKeyTermMetaField(
+                __(
+                    'Please enter only numbers, maximum 3 digits, leading zeros are allowed.',
+                    'fau-degree-program'
+                ),
+                '/^[0-9]{1,3}$/',
+            )),
             new EnglishNameTermMetaField(),
         );
         $termMetaRegistrar->register(
@@ -135,6 +156,13 @@ final class TermMetaModule implements ServiceModule, ExecutableModule
     private static function degreeMetaFields(): array
     {
         return [
+            (new CampoKeyTermMetaField(
+                __(
+                    'Please enter lowercase alphanumeric characters and maximum 3 characters.',
+                    'fau-degree-program'
+                ),
+                '/^[a-z0-9]{1,3}$/',
+            )),
             new InputTermMetaField(
                 Degree::ABBREVIATION,
                 _x(

--- a/src/Infrastructure/Dashboard/TermMeta/TermMetaModule.php
+++ b/src/Infrastructure/Dashboard/TermMeta/TermMetaModule.php
@@ -162,7 +162,6 @@ final class TermMetaModule implements ServiceModule, ExecutableModule
             ...(new MultilingualLinkTermMetaFields())->getArrayCopy(),
         );
 
-
         add_action(
             AssetManager::ACTION_SETUP,
             [$container->get(AssetsLoader::class), 'load']

--- a/templates/term-meta/partials/input.php
+++ b/templates/term-meta/partials/input.php
@@ -2,8 +2,17 @@
 
 declare(strict_types=1);
 
+use Fau\DegreeProgram\Infrastructure\Dashboard\TermMeta\TermMetaFieldValidationPattern;
+
 /**
- * @var array{key: string, value: string, title: string, description: string, type: string, pattern?: string} $data
+ * @var array{
+ *      key: string,
+ *      value: string,
+ *      title: string,
+ *      description: string,
+ *      type: string,
+ *      validationPattern: ?TermMetaFieldValidationPattern
+ * } $data
  */
 
 [
@@ -11,25 +20,26 @@ declare(strict_types=1);
     'value' => $value,
     'description' => $description,
     'type' => $type,
+    'validationPattern' => $validationPattern,
 ] = $data;
-
-$pattern = isset($data['pattern']) ? $data['pattern'] : null;
 
 ?>
 
 
-<input name="<?= esc_attr($key) ?>"
-       id="<?= esc_attr($key) ?>"
-       type="<?= esc_attr($type) ?>"
-       value="<?= esc_attr($value) ?>"
-       size="40"
-       <?php if ($description) : ?>
-           aria-describedby="<?= esc_attr($key) ?>-description"
-       <?php endif ?>
+<input
+    name="<?= esc_attr($key) ?>"
+    id="<?= esc_attr($key) ?>"
+    type="<?= esc_attr($type) ?>"
+    value="<?= esc_attr($value) ?>"
+    size="40"
+    <?php if ($description) : ?>
+        aria-describedby="<?= esc_attr($key) ?>-description"
+    <?php endif ?>
 
-       <?php if (! is_null($pattern)) : ?>
-           pattern="<?= esc_attr($pattern) ?>"
-       <?php endif ?>
+    <?php if (! is_null($validationPattern)) : ?>
+        pattern="<?= esc_attr($validationPattern->pattern()) ?>"
+        title="<?= esc_attr($validationPattern->expectedPatternMessage()) ?>"
+    <?php endif ?>
 />
 <?php if ($description) : ?>
     <p class="description" id="<?= esc_attr($key) ?>-description">

--- a/templates/term-meta/partials/input.php
+++ b/templates/term-meta/partials/input.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * @var array{key: string, value: string, title: string, description: string, type: string} $data
+ * @var array{key: string, value: string, title: string, description: string, type: string, pattern?: string} $data
  */
 
 [
@@ -12,6 +12,8 @@ declare(strict_types=1);
     'description' => $description,
     'type' => $type,
 ] = $data;
+
+$pattern = isset($data['pattern']) ? $data['pattern'] : null;
 
 ?>
 
@@ -23,7 +25,11 @@ declare(strict_types=1);
        size="40"
        <?php if ($description) : ?>
            aria-describedby="<?= esc_attr($key) ?>-description"
-       <?php endif; ?>
+       <?php endif ?>
+
+       <?php if (! is_null($pattern)) : ?>
+           pattern="<?= esc_attr($pattern) ?>"
+       <?php endif ?>
 />
 <?php if ($description) : ?>
     <p class="description" id="<?= esc_attr($key) ?>-description">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,7 @@ module.exports = {
         'css/degree-program-list-table': './resources/scss/degree-program-list-table.scss',
         'ts/degree-program-editor': './resources/ts/degree-program-editor.ts',
         'ts/degree-program-list-table': './resources/ts/degree-program-list-table.ts',
+        'ts/term-meta-fields-validation': './resources/ts/term-meta-fields-validation.ts',
     },
     output: {
         publicPath: './',


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-411


**What is the new behavior (if this is a feature change)?**
- Added campo-key field for the following taxonomies: `abschluss`, `area_of_study`, `faechergruppe`, `standort` with validation rules.
- Add validation error messages both on backend and javascript (HTML5 validation).


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
