### PR TITLE
Add initial Campo keys value to degree programs

### DIFF
--- a/src/Infrastructure/Migration/Migration0015CampoKeyMeta.php
+++ b/src/Infrastructure/Migration/Migration0015CampoKeyMeta.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fau\DegreeProgram\Infrastructure\Migration;
+
+use Fau\DegreeProgram\Common\Application\Cache\CacheKeyGenerator;
+use Fau\DegreeProgram\Common\Application\DegreeProgramViewTranslated;
+use Fau\DegreeProgram\Common\Domain\DegreeProgram;
+use Fau\DegreeProgram\Common\Domain\DegreeProgramId;
+use Fau\DegreeProgram\Common\Infrastructure\Cache\PostMetaDegreeProgramCache;
+use Fau\DegreeProgram\Common\Infrastructure\Content\PostType\DegreeProgramPostType;
+use Psr\SimpleCache\CacheInterface;
+
+final class Migration0015CampoKeyMeta
+{
+    public function __construct(
+        private CacheKeyGenerator $cacheKeyGenerator,
+        private CacheInterface $cache
+    ) {
+    }
+
+    public function __invoke(): void
+    {
+        /** @var array<int> $degreeProgramIds */
+        $degreeProgramIds = get_posts([
+            'post_type' => [DegreeProgramPostType::KEY, 'revision'],
+            'post_status' => ['any', 'trash', 'inherit'],
+            'posts_per_page' => -1,
+            'meta_query' => [
+                'relation' => 'OR',
+                [
+                    'key' => PostMetaDegreeProgramCache::postMetaKey(
+                        CacheKeyGenerator::RAW_TYPE
+                    ),
+                    'compare' => 'EXISTS',
+                ],
+                [
+                    'key' => PostMetaDegreeProgramCache::postMetaKey(
+                        CacheKeyGenerator::TRANSLATED_TYPE
+                    ),
+                    'compare' => 'EXISTS',
+                ],
+            ],
+            'fields' => 'ids',
+        ]);
+
+        foreach ($degreeProgramIds as $id) {
+            foreach ([CacheKeyGenerator::RAW_TYPE, CacheKeyGenerator::TRANSLATED_TYPE] as $type) {
+                $this->initializeCampoKeys($id, $type);
+            }
+        }
+    }
+
+    /**
+     * @psalm-param 'raw'|'translated' $type
+     */
+    private function initializeCampoKeys(int $id, string $type): void
+    {
+        $key = $this->cacheKeyGenerator->generateForDegreeProgram(
+            DegreeProgramId::fromInt($id),
+            $type
+        );
+
+        /** @var array|null $data */
+        $data = $this->cache->get($key);
+
+        if (is_null($data)) {
+            return;
+        }
+
+        $data[DegreeProgram::CAMPO_KEYS] = [];
+
+        if (
+            isset($data[DegreeProgramViewTranslated::TRANSLATIONS])
+            && is_array($data[DegreeProgramViewTranslated::TRANSLATIONS])
+        ) {
+            foreach ($data[DegreeProgramViewTranslated::TRANSLATIONS] as &$translation) {
+                is_array($translation) && $translation[DegreeProgram::CAMPO_KEYS] = [];
+            }
+        }
+
+        $this->cache->set($key, $data);
+    }
+}

--- a/src/Infrastructure/Migration/MigrationModule.php
+++ b/src/Infrastructure/Migration/MigrationModule.php
@@ -41,6 +41,14 @@ final class MigrationModule implements ServiceModule, ExecutableModule
                 );
             },
             Migration13RemoveCustomOrdering::class => static fn() => new Migration13RemoveCustomOrdering(),
+            Migration0015CampoKeyMeta::class => static function (
+                ContainerInterface $container
+            ): Migration0015CampoKeyMeta {
+                return new Migration0015CampoKeyMeta(
+                    $container->get(CacheKeyGenerator::class),
+                    $container->get(CacheInterface::class)
+                );
+            },
         ];
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
We are currently having issues with cached degree program data. The post meta values `fau_cache_degree_program_raw` and `fau_cache_degree_program_translated` don't include `campo_keys` value. I think, the proper solution is to create a new migration that initializes this data.
Consuming websites must invalidate their degree program caches to sync with the updated `campo_keys` values, otherwise, errors will occur.


**What is the new behavior (if this is a feature change)?**
Added new migration to initialize `campo_keys` value for degree programs.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
