### PR TITLE
[FAU-376] Include admission requirement slug in degree program data on editor form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,8 @@
     "scripts": {
         "check-coding-standards": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
         "check-psalm": "@php ./vendor/vimeo/psalm/psalm --output-format=compact --no-cache",
-        "fix-coding-standards": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+        "fix-coding-standards": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf",
+        "tests": "@php ./vendor/phpunit/phpunit/phpunit --coverage-text",
+        "tests:no-cov": "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
     }
 }

--- a/resources/ts/defs/degree-program-data.ts
+++ b/resources/ts/defs/degree-program-data.ts
@@ -122,4 +122,5 @@ export interface DegreeProgramPost extends Post {
 
 export interface AdmissionRequirement extends MultilingualLink {
 	parent: AdmissionRequirement | null;
+	slug: string;
 }

--- a/resources/ts/util/transforms.ts
+++ b/resources/ts/util/transforms.ts
@@ -97,6 +97,8 @@ export function transformTermToAdmissionRequirement(
 		term
 	) as AdmissionRequirement;
 
+	admissionRequirement.slug = term?.slug ?? '';
+
 	if ( ! term ) {
 		return admissionRequirement;
 	}

--- a/src/Infrastructure/Repository/TermsRepository.php
+++ b/src/Infrastructure/Repository/TermsRepository.php
@@ -40,6 +40,7 @@ final class TermsRepository extends BilingualRepository
         return AdmissionRequirement::new(
             $this->bilingualLinkFromTerm($term),
             $parent instanceof WP_Term ? $this->admissionRequirement($parent) : null,
+            $term->slug
         );
     }
 }

--- a/tests/js/__mocks__/admission-requirements.ts
+++ b/tests/js/__mocks__/admission-requirements.ts
@@ -19,6 +19,7 @@ export const mockFreiAdmissionRequirement: DegreeProgramData['admission_requirem
             en: 'frei',
         },
         parent: null,
+        slug: 'frei'
     };
 
 export const mockAbcAdmissionRequirement: DegreeProgramData['admission_requirements']['bachelor_or_teaching_degree'] =
@@ -40,4 +41,5 @@ export const mockAbcAdmissionRequirement: DegreeProgramData['admission_requireme
             en: 'abc',
         },
         parent: null,
+        slug: 'abc'
     };


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


**What is the current behavior?** (You can also link to an open issue here)
If you remove an admission requirement in the degree program editor form and try to save the degree program, you'll encounter an error indicating that the slug field is required by the schema.


**What is the new behavior (if this is a feature change)?**
Since the `slug` field is required in the schema, the degree program editor form should also be updated to include the slug for admission requirements.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
