### PR TITLE
[FAU-441] feat: update modified value if any of degree program properties were updated

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -411,12 +411,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/RRZE-Webteam/FAU-Studium-Common.git",
-                "reference": "d8cb53c2cf24a6f28b07109cec9bb67c1d51d743"
+                "reference": "059457f63e219f1fd3a0d8b3d3b063d7ea2b40db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/RRZE-Webteam/FAU-Studium-Common/zipball/d8cb53c2cf24a6f28b07109cec9bb67c1d51d743",
-                "reference": "d8cb53c2cf24a6f28b07109cec9bb67c1d51d743",
+                "url": "https://api.github.com/repos/RRZE-Webteam/FAU-Studium-Common/zipball/059457f63e219f1fd3a0d8b3d3b063d7ea2b40db",
+                "reference": "059457f63e219f1fd3a0d8b3d3b063d7ea2b40db",
                 "shasum": ""
             },
             "require": {
@@ -488,7 +488,7 @@
                 "source": "https://github.com/RRZE-Webteam/FAU-Studium-Common/tree/main",
                 "issues": "https://github.com/RRZE-Webteam/FAU-Studium-Common/issues"
             },
-            "time": "2024-07-23T13:46:52+00:00"
+            "time": "2024-09-04T10:07:44+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/Infrastructure/Cache/WhenCacheInvalidated.php
+++ b/src/Infrastructure/Cache/WhenCacheInvalidated.php
@@ -6,11 +6,16 @@ namespace Fau\DegreeProgram\Infrastructure\Cache;
 
 use Fau\DegreeProgram\Common\Application\Event\CacheInvalidated;
 use Fau\DegreeProgram\Common\Application\Queue\MessageBus;
+use Fau\DegreeProgram\Common\Domain\DegreeProgramId;
+use Fau\DegreeProgram\Common\Infrastructure\Content\PostType\DegreeProgramPostType;
+use Fau\DegreeProgram\Common\Infrastructure\Repository\TimestampRepository;
 
 final class WhenCacheInvalidated
 {
-    public function __construct(private MessageBus $messageBus)
-    {
+    public function __construct(
+        private MessageBus $messageBus,
+        private TimestampRepository $timestampRepository,
+    ) {
     }
 
     public function scheduleWarming(CacheInvalidated $event): void
@@ -18,5 +23,28 @@ final class WhenCacheInvalidated
         $this->messageBus->dispatch(
             WarmCacheMessage::new($event->isFully(), $event->ids())
         );
+    }
+
+    public function updateModifiedDate(CacheInvalidated $event): void
+    {
+        if ($event->reason() !== CacheInvalidated::DATA_CHANGED) {
+            return;
+        }
+
+        $ids = $event->ids();
+
+        if ($event->isFully()) {
+            /** @var array<int> $ids */
+            $ids = get_posts([
+                'numberposts' => -1,
+                'post_type' => DegreeProgramPostType::KEY,
+                'post_status' => 'any',
+                'fields' => 'ids',
+            ]);
+        }
+
+        foreach ($ids as $id) {
+            $this->timestampRepository->updateModified(DegreeProgramId::fromInt($id));
+        }
     }
 }

--- a/src/Infrastructure/Cache/WhenDegreeProgramSharedPropertyUpdated.php
+++ b/src/Infrastructure/Cache/WhenDegreeProgramSharedPropertyUpdated.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fau\DegreeProgram\Infrastructure\Cache;
 
 use Fau\DegreeProgram\Common\Application\Cache\CacheInvalidator;
+use Fau\DegreeProgram\Common\Application\Event\CacheInvalidated;
 
 final class WhenDegreeProgramSharedPropertyUpdated
 {
@@ -23,6 +24,6 @@ final class WhenDegreeProgramSharedPropertyUpdated
         }
 
         $once = true;
-        $this->cacheInvalidator->invalidateFully();
+        $this->cacheInvalidator->invalidateFully(CacheInvalidated::DATA_CHANGED);
     }
 }

--- a/src/Infrastructure/Cache/WhenDegreeProgramTermUpdated.php
+++ b/src/Infrastructure/Cache/WhenDegreeProgramTermUpdated.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fau\DegreeProgram\Infrastructure\Cache;
 
 use Fau\DegreeProgram\Common\Application\Cache\CacheInvalidator;
+use Fau\DegreeProgram\Common\Application\Event\CacheInvalidated;
 use Fau\DegreeProgram\Common\Infrastructure\Content\PostType\DegreeProgramPostType;
 use Psr\SimpleCache\InvalidArgumentException;
 
@@ -25,7 +26,7 @@ final class WhenDegreeProgramTermUpdated
             return;
         }
 
-        $this->cacheInvalidator->invalidatePartially($ids);
+        $this->cacheInvalidator->invalidatePartially($ids, CacheInvalidated::DATA_CHANGED);
     }
 
     /**

--- a/src/Infrastructure/Cache/WhenDegreeProgramUpdated.php
+++ b/src/Infrastructure/Cache/WhenDegreeProgramUpdated.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fau\DegreeProgram\Infrastructure\Cache;
 
 use Fau\DegreeProgram\Common\Application\Cache\CacheInvalidator;
+use Fau\DegreeProgram\Common\Application\Event\CacheInvalidated;
 use Fau\DegreeProgram\Common\Domain\DegreeProgram;
 use Fau\DegreeProgram\Common\Domain\Event\DegreeProgramUpdated;
 use Fau\DegreeProgram\Common\Infrastructure\Content\PostType\DegreeProgramPostType;
@@ -27,7 +28,7 @@ final class WhenDegreeProgramUpdated
         $limitedCombinationIds = $this->findRelatedIds(DegreeProgram::LIMITED_COMBINATIONS, $postId);
         $ids = array_unique(array_merge([$postId], $combinationIds, $limitedCombinationIds));
 
-        $this->cacheInvalidator->invalidatePartially($ids);
+        $this->cacheInvalidator->invalidatePartially($ids, CacheInvalidated::DATA_CHANGED);
     }
 
     /**

--- a/src/Infrastructure/Repository/RepositoryModule.php
+++ b/src/Infrastructure/Repository/RepositoryModule.php
@@ -16,6 +16,7 @@ use Fau\DegreeProgram\Common\Infrastructure\Content\Taxonomy\TaxonomiesList;
 use Fau\DegreeProgram\Common\Infrastructure\Repository\CampoKeysRepository;
 use Fau\DegreeProgram\Common\Infrastructure\Repository\FacultyRepository;
 use Fau\DegreeProgram\Common\Infrastructure\Repository\IdGenerator;
+use Fau\DegreeProgram\Common\Infrastructure\Repository\TimestampRepository;
 use Fau\DegreeProgram\Common\Infrastructure\Repository\WordPressDatabaseDegreeProgramCollectionRepository;
 use Fau\DegreeProgram\Common\Infrastructure\Repository\WordPressDatabaseDegreeProgramRepository;
 use Fau\DegreeProgram\Common\Infrastructure\Repository\WordPressDatabaseDegreeProgramViewRepository;
@@ -43,6 +44,7 @@ class RepositoryModule implements ServiceModule
             CampoKeysRepository::class => static fn() => new CampoKeysRepository(),
             ConditionalFieldsFilter::class => static fn() => new ConditionalFieldsFilter(),
             FacultyRepository::class => static fn() => new FacultyRepository(),
+            TimestampRepository::class => static fn() => new TimestampRepository(),
             DegreeProgramRepository::class => static fn(ContainerInterface $container) => new WordPressDatabaseDegreeProgramRepository(
                 $container->get(IdGenerator::class),
                 $container->get(EventDispatcherInterface::class),
@@ -54,6 +56,7 @@ class RepositoryModule implements ServiceModule
                 $container->get(HtmlDegreeProgramSanitizer::class),
                 $container->get(ConditionalFieldsFilter::class),
                 $container->get(FacultyRepository::class),
+                $container->get(TimestampRepository::class),
             ),
             DegreeProgramViewRepository::class => static fn(ContainerInterface $container) => new CachedDegreeProgramViewRepository(
                 $container->get(self::VIEW_REPOSITORY_UNCACHED),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature.


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-441


**What is the new behavior (if this is a feature change)?**
I wouldn't say I like the coupling of the new functionality with the cache module, but now the cache module is the single place where we have all hooks triggered for any degree program data changes. Decoupling the functionality is a huge and dangerous refactoring effort. Anyway, we already have a cache module coupled with revision functionality and the degree program output plugin can't work without a cache at all (at least for degree program overviews). So our "cache" is not a secondary but a core functionality now :man_shrugging: .

The same is true for extracting helper repositories. We have many [domain-related repositories](https://github.com/RRZE-Webteam/FAU-Studium-Common/tree/bf4747fbc7d5934a687a0b4a558e2aab225995c8/src/Infrastructure/Repository), so creating new repositories just to wrap the `get_posts` invocation doesn't make much sense.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
