### PR TITLE
[FAU-434] Remove campo keys from degree program revision data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Removed campo keys from degree program revision data.
+
 ## [2.0.1] - 2024-08-07
 
 ### Fixed

--- a/src/Infrastructure/Repository/CacheBasedRevisionRepository.php
+++ b/src/Infrastructure/Repository/CacheBasedRevisionRepository.php
@@ -156,7 +156,6 @@ final class CacheBasedRevisionRepository implements DegreeProgramRevisionReposit
                 DegreeProgram::COMBINATIONS => $this->combinationsToContextualIdList($rawRevision->combinations()),
                 DegreeProgram::LIMITED_COMBINATIONS => $this->combinationsToContextualIdList($rawRevision->limitedCombinations()),
                 DegreeProgram::APPLY_NOW_LINK => $this->structureToContextualId($rawRevision->applyNowLink()),
-                DegreeProgram::CAMPO_KEYS => implode(', ', $rawRevision->campoKeys()->asArray()),
             ],
             self::multilingualStringToFlatArray(DegreeProgram::ENTRY_TEXT, $rawRevision->entryText()),
         );


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


**What is the current behavior?** (You can also link to an open issue here)
If campo keys are updated on the providing website and we restore the degree program with the old keys, the terms on the consuming website will receive the old campo keys. This happens because we sync campo keys based on the degree program data. It turns out that it is better to remove this data from the revision.


**What is the new behavior (if this is a feature change)?**
We don't restore campo keys from revision data.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
