### PR TITLE
[FAU-455] Support new blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support `fau/faudir-block` and `fau-degree-program/shares` blocks in content fields.
+
 ## [2.2.0] - 2025-03-17
 
 ### Added

--- a/composer.lock
+++ b/composer.lock
@@ -401,12 +401,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/RRZE-Webteam/FAU-Studium-Common.git",
-                "reference": "c58b1817ecf9331bc8a76f90fd12ff57c139d09e"
+                "reference": "27a48b5e40b87e66b4a1ecba5965bd78e77ebef1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/RRZE-Webteam/FAU-Studium-Common/zipball/c58b1817ecf9331bc8a76f90fd12ff57c139d09e",
-                "reference": "c58b1817ecf9331bc8a76f90fd12ff57c139d09e",
+                "url": "https://api.github.com/repos/RRZE-Webteam/FAU-Studium-Common/zipball/27a48b5e40b87e66b4a1ecba5965bd78e77ebef1",
+                "reference": "27a48b5e40b87e66b4a1ecba5965bd78e77ebef1",
                 "shasum": ""
             },
             "require": {
@@ -479,7 +479,7 @@
                 "source": "https://github.com/RRZE-Webteam/FAU-Studium-Common/tree/main",
                 "issues": "https://github.com/RRZE-Webteam/FAU-Studium-Common/issues"
             },
-            "time": "2025-03-05T10:37:59+00:00"
+            "time": "2025-04-29T10:18:09+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/resources/ts/components/ContentField/constants.ts
+++ b/resources/ts/components/ContentField/constants.ts
@@ -9,6 +9,8 @@ export const ALLOWED_BLOCK_TYPES = [
 	'fau/description-list',
 	'fau/description-term',
 	'fau/description-details',
+	'fau/faudir-block',
+	'fau-degree-program/shares',
 ];
 
 export const ALLOWED_MIME_TYPES = {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-455


**What is the new behavior (if this is a feature change)?**
Allow the "fau/faudir-block" and the "fau-degree-program/shares" blocks in content fields.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
Related PR: https://github.com/RRZE-Webteam/FAU-Studium-Common/pull/24