### PR TITLE
Fix React deprecation warnings

### DIFF
--- a/resources/ts/components/CircularProgress/CircularProgress.tsx
+++ b/resources/ts/components/CircularProgress/CircularProgress.tsx
@@ -62,10 +62,4 @@ const CircularProgressBar = ( {
 		</StyledSvgCircle>
 	);
 };
-
-CircularProgressBar.defaultProps = {
-	squareSize: DEFAULT_SQUARE_SIZE,
-	strokeWidth: DEFAULT_STROKE_WIDTH,
-};
-
 export default CircularProgressBar;

--- a/resources/ts/components/ContentField/ContentField.tsx
+++ b/resources/ts/components/ContentField/ContentField.tsx
@@ -85,7 +85,11 @@ const BlockDeselectListener = ( {
  * @param {function(string): void} onChange Callback to update content
  * @param {?boolean}               required Is required?
  */
-const ContentField = ( { content, onChange, required }: ContentFieldProps ) => {
+const ContentField = ( {
+	content,
+	onChange,
+	required = false,
+}: ContentFieldProps ) => {
 	const [ currentBlocks, setCurrentBlocks ] = useState( parse( content ) );
 	const editorRef = useRef< HTMLDivElement >( null );
 
@@ -150,10 +154,6 @@ const ContentField = ( { content, onChange, required }: ContentFieldProps ) => {
 			</div>
 		</BlockEditorProvider>
 	);
-};
-
-ContentField.defaultProps = {
-	required: false,
 };
 
 export default ContentField;

--- a/resources/ts/components/ImageField/ImageField.tsx
+++ b/resources/ts/components/ImageField/ImageField.tsx
@@ -131,7 +131,3 @@ export default function ImageField( { path, title = '' }: ImageFieldProps ) {
 		</MediaUploadCheck>
 	);
 }
-
-ImageField.defaultProps = {
-	title: '',
-};

--- a/resources/ts/components/Layouts/FormFieldLabel.tsx
+++ b/resources/ts/components/Layouts/FormFieldLabel.tsx
@@ -19,17 +19,13 @@ const StyledHelpText = styled.p`
 	color: rgb( 117, 117, 117 );
 `;
 
-const FormFieldLabel = ( { label, help }: Props ) => {
+const FormFieldLabel = ( { label, help = undefined }: Props ) => {
 	return (
 		<>
 			<StyledLabel>{ label }</StyledLabel>
 			{ !! help && <StyledHelpText>{ help }</StyledHelpText> }
 		</>
 	);
-};
-
-FormFieldLabel.defaultProps = {
-	help: undefined,
 };
 
 export default FormFieldLabel;

--- a/resources/ts/components/LimitedInputControl/LimitedInputControl.tsx
+++ b/resources/ts/components/LimitedInputControl/LimitedInputControl.tsx
@@ -61,8 +61,4 @@ const LimitedInputControl = ( {
 	);
 };
 
-LimitedInputControl.defaultProps = {
-	required: false,
-};
-
 export default LimitedInputControl;

--- a/resources/ts/components/TextControlCollection/TextControlCollection.tsx
+++ b/resources/ts/components/TextControlCollection/TextControlCollection.tsx
@@ -149,10 +149,4 @@ const TextControlCollection = ( {
 		</div>
 	);
 };
-
-TextControlCollection.defaultProps = {
-	emptyMessage: undefined,
-	type: 'text',
-} as Partial< Props >;
-
 export default TextControlCollection;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


**What is the current behavior?** (You can also link to an open issue here)
Numerous warnings are displayed stating:
"Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.":

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/5536319d-4b64-430c-b35d-d3b10dba464f" />


**What is the new behavior (if this is a feature change)?**
The warnings related to defaultProps usage in function components have been resolved. This cleanup reduces console noise.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
