### PR TITLE
[FAU-433] Prevent block replacement on pasting content

### DIFF
--- a/resources/ts/components/ContentField/ContentField.tsx
+++ b/resources/ts/components/ContentField/ContentField.tsx
@@ -92,6 +92,37 @@ const ContentField = ( {
 }: ContentFieldProps ) => {
 	const [ currentBlocks, setCurrentBlocks ] = useState( parse( content ) );
 	const editorRef = useRef< HTMLDivElement >( null );
+	const { selectionChange } = useDispatch( 'core/block-editor' );
+
+	// Prevent block replacement when pasting content
+	useEffect( () => {
+		const container = editorRef.current;
+
+		if ( ! container ) {
+			return;
+		}
+
+		const handlePaste = ( event: ClipboardEvent ) => {
+			const target = event.target as HTMLElement;
+			const isWithinNestedEditor = container.contains( target );
+
+			if ( isWithinNestedEditor ) {
+				const blockElement = target.closest( '[data-block]' );
+
+				if ( blockElement ) {
+					const blockId = blockElement.getAttribute( 'data-block' );
+
+					if ( blockId ) {
+						selectionChange( blockId, 'content' );
+					}
+				}
+			}
+		};
+
+		container.addEventListener( 'paste', handlePaste, true );
+		return () =>
+			container.removeEventListener( 'paste', handlePaste, true );
+	}, [ selectionChange ] );
 
 	/**
 	 * The `onChange` callback is fired only when changes are considered final,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-433


**What is the new behavior (if this is a feature change)?**

When users paste content into the content field, the Gutenberg attempts to replace the entire Degree Program block with a paragraph block. However, due to the template lock, the action is blocked and nothing is pasted.

### Steps to Reproduce
1. Open a Degree program editor
2. Click inside a paragraph block within the content field
3. Paste any formatted text content
4. **Expected**: Text should be inserted into the existing paragraph
5. **Actual**: Nothing is pasted.

### Root Cause

The issue originates from WordPress Gutenberg's `__unstableIsFullySelected()` [function](https://github.com/WordPress/gutenberg/blob/8189c9304bd6749f8ef43aa446e27e34eed245e5/packages/block-editor/src/store/selectors.js#L1026-L1035), which determines whether a block selection is "full" (entire block) or "partial" (content within a block).

### Technical Details

Custom blocks that use `BlockEditorProvider` create a nested editor context that exists separately from the main WordPress editor. This architectural pattern creates a disconnect in WordPress's selection system.

When a user clicks into the nested editor:
- WordPress sees selection within the nested context
- But the parent editor doesn't know about the nested selection
- Selection state remains: `{ clientId: 'parent-block' }` (no `attributeKey`)
- `__unstableIsFullySelected()` returns true (thinks entire block is selected)

### Proposed solution

Implement a paste event listener that intercepts paste operations and sets the proper selection state with an `attributeKey`, (it means we are editing within a block, not replacing the whole block) before WordPress processes the paste.

### Implementation Details

1. **Event Interception**: Add a paste event listener using the capture phase to run before WordPress's paste handling
2. **Selection State Override**: Set `attributeKey: 'content'` to indicate the user is editing within a block
3. **Targeted Application**: Only apply the fix when pasting within the ContentField's nested editor


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
