### PR TITLE
[FAU-463] Remove teaser image input field from editor

### DIFF
--- a/resources/ts/components/DegreeProgramEditForm/General.tsx
+++ b/resources/ts/components/DegreeProgramEditForm/General.tsx
@@ -101,19 +101,6 @@ const General = () => {
 					>
 						<ImageField path="featured_image" />
 					</FormField>
-					<FormField
-						name="teaser_image"
-						fill="half"
-						label={ _x(
-							'Teaser Image',
-							'backoffice: degree program edit form',
-							'fau-degree-program'
-						) }
-						help="Wird für die Kacheln auf der Auswahlseite verwendet. Größe: 500 × 500 px."
-						required
-					>
-						<ImageField path="teaser_image" />
-					</FormField>
 
 					<FormField
 						name="entry_text"

--- a/resources/ts/components/DegreeProgramEditForm/constants.ts
+++ b/resources/ts/components/DegreeProgramEditForm/constants.ts
@@ -9,7 +9,6 @@ export const FIELDS_BY_TABS: Record<
 		'title',
 		'subtitle',
 		'featured_image',
-		'teaser_image',
 		'entry_text',
 		'area_of_study',
 		'start',

--- a/resources/ts/components/ImageField/ImageField.tsx
+++ b/resources/ts/components/ImageField/ImageField.tsx
@@ -17,7 +17,7 @@ import useMedia from './useMedia';
 import { Image } from '../../defs';
 
 type ImageFieldProps = {
-	path: 'teaser_image' | 'featured_image';
+	path: 'featured_image';
 	title?: string;
 };
 

--- a/resources/ts/defs/degree-program-data.ts
+++ b/resources/ts/defs/degree-program-data.ts
@@ -5,7 +5,6 @@ import { ObjectValues, Paths } from './generic';
 export interface DegreeProgramData {
 	id: number;
 	featured_image: Image;
-	teaser_image: Image;
 	title: MultilingualString;
 	subtitle: MultilingualString;
 	standard_duration: string;

--- a/resources/ts/util/transformedErrorMessages.ts
+++ b/resources/ts/util/transformedErrorMessages.ts
@@ -9,10 +9,6 @@ const transformedErrorMessages: Partial<
 		'Please select a featured image.',
 		'fau-degree-program'
 	),
-	'teaser_image.id': __(
-		'Please select a teaser image.',
-		'fau-degree-program'
-	),
 };
 
 const transformedErrorMessagesBasedOnErrorCode: Partial<

--- a/src/Infrastructure/Repository/CacheBasedRevisionRepository.php
+++ b/src/Infrastructure/Repository/CacheBasedRevisionRepository.php
@@ -94,7 +94,6 @@ final class CacheBasedRevisionRepository implements DegreeProgramRevisionReposit
             [
                 DegreeProgramRevision::STATUS => self::status($revisionId->asInt()),
                 DegreeProgram::FEATURED_IMAGE => self::imageToContextualId($rawRevision->featuredImage()),
-                DegreeProgram::TEASER_IMAGE => self::imageToContextualId($rawRevision->teaserImage()),
             ],
             self::multilingualStringToFlatArray(DegreeProgram::TITLE, $rawRevision->title()),
             self::multilingualStringToFlatArray(DegreeProgram::SUBTITLE, $rawRevision->subtitle()),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-463


**What is the new behavior (if this is a feature change)?**
Removes the teaser image input from the degree program edit form, along with its validation message and revision mapping.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
Related PR - https://github.com/RRZE-Webteam/FAU-Studium-Common/pull/30