### PR TITLE
[FAU-469] Defer translations to init hook

### DIFF
--- a/src/Infrastructure/Dashboard/AdminBarModule.php
+++ b/src/Infrastructure/Dashboard/AdminBarModule.php
@@ -19,42 +19,47 @@ final class AdminBarModule implements ExecutableModule
 
     public function run(ContainerInterface $container): bool
     {
-        $cacheInvalidationAction = AdminPostAction::new(
-            'invalidate_degree_program_cache',
-            Closure::fromCallable(
-                [$container->get(CacheInvalidator::class), 'invalidateFully']
-            )
-        )->withSuccessMessage(
-            _x(
-                'Degree program cache invalidated.',
-                'backoffice: admin notice',
-                'fau-degree-program'
-            )
-        )
-        ->withErrorMessage(
-            _x(
-                'Could not invalidate degree program cache.',
-                'backoffice: admin notice',
-                'fau-degree-program'
-            )
-        );
-
-        $cacheInvalidationAction->register();
-
-        $adminBar = AdminBarMenu::new()
-            ->withMenuItem(
-                MenuItem::new(
-                    'invalidate-cache',
+        add_action(
+            'init',
+            static function () use ($container): void {
+                $cacheInvalidationAction = AdminPostAction::new(
+                    'invalidate_degree_program_cache',
+                    Closure::fromCallable(
+                        [$container->get(CacheInvalidator::class), 'invalidateFully']
+                    )
+                )->withSuccessMessage(
                     _x(
-                        'Invalidate degree program caches',
-                        'backoffice: admin bar menu item',
+                        'Degree program cache invalidated.',
+                        'backoffice: admin notice',
                         'fau-degree-program'
-                    ),
-                    $cacheInvalidationAction->buildUrl()
+                    )
                 )
-            );
+                ->withErrorMessage(
+                    _x(
+                        'Could not invalidate degree program cache.',
+                        'backoffice: admin notice',
+                        'fau-degree-program'
+                    )
+                );
 
-        add_action('admin_bar_menu', [$adminBar, 'render'], 100);
+                $cacheInvalidationAction->register();
+
+                $adminBar = AdminBarMenu::new()
+                    ->withMenuItem(
+                        MenuItem::new(
+                            'invalidate-cache',
+                            _x(
+                                'Invalidate degree program caches',
+                                'backoffice: admin bar menu item',
+                                'fau-degree-program'
+                            ),
+                            $cacheInvalidationAction->buildUrl()
+                        )
+                    );
+
+                add_action('admin_bar_menu', [$adminBar, 'render'], 100);
+            }
+        );
 
         return true;
     }

--- a/src/Infrastructure/Dashboard/AdminBarModule.php
+++ b/src/Infrastructure/Dashboard/AdminBarModule.php
@@ -19,48 +19,53 @@ final class AdminBarModule implements ExecutableModule
 
     public function run(ContainerInterface $container): bool
     {
-        add_action(
-            'init',
-            static function () use ($container): void {
-                $cacheInvalidationAction = AdminPostAction::new(
-                    'invalidate_degree_program_cache',
-                    Closure::fromCallable(
-                        [$container->get(CacheInvalidator::class), 'invalidateFully']
-                    )
-                )->withSuccessMessage(
-                    _x(
-                        'Degree program cache invalidated.',
-                        'backoffice: admin notice',
-                        'fau-degree-program'
-                    )
-                )
-                ->withErrorMessage(
-                    _x(
-                        'Could not invalidate degree program cache.',
-                        'backoffice: admin notice',
-                        'fau-degree-program'
-                    )
-                );
-
-                $cacheInvalidationAction->register();
-
-                $adminBar = AdminBarMenu::new()
-                    ->withMenuItem(
-                        MenuItem::new(
-                            'invalidate-cache',
-                            _x(
-                                'Invalidate degree program caches',
-                                'backoffice: admin bar menu item',
-                                'fau-degree-program'
-                            ),
-                            $cacheInvalidationAction->buildUrl()
-                        )
-                    );
-
-                add_action('admin_bar_menu', [$adminBar, 'render'], 100);
-            }
-        );
+        add_action('init', fn () => $this->registerAdminBar($container));
 
         return true;
+    }
+
+    /**
+     * Deferred to `init` so translated labels don't load too early (WP 6.7).
+     *
+     * @wp-hook init
+     */
+    private function registerAdminBar(ContainerInterface $container): void
+    {
+        $cacheInvalidationAction = AdminPostAction::new(
+            'invalidate_degree_program_cache',
+            Closure::fromCallable(
+                [$container->get(CacheInvalidator::class), 'invalidateFully']
+            )
+        )->withSuccessMessage(
+            _x(
+                'Degree program cache invalidated.',
+                'backoffice: admin notice',
+                'fau-degree-program'
+            )
+        )
+        ->withErrorMessage(
+            _x(
+                'Could not invalidate degree program cache.',
+                'backoffice: admin notice',
+                'fau-degree-program'
+            )
+        );
+
+        $cacheInvalidationAction->register();
+
+        $adminBar = AdminBarMenu::new()
+            ->withMenuItem(
+                MenuItem::new(
+                    'invalidate-cache',
+                    _x(
+                        'Invalidate degree program caches',
+                        'backoffice: admin bar menu item',
+                        'fau-degree-program'
+                    ),
+                    $cacheInvalidationAction->buildUrl()
+                )
+            );
+
+        add_action('admin_bar_menu', [$adminBar, 'render'], 100);
     }
 }

--- a/src/Infrastructure/Dashboard/Settings/SettingsModule.php
+++ b/src/Infrastructure/Dashboard/Settings/SettingsModule.php
@@ -59,47 +59,52 @@ final class SettingsModule implements ServiceModule, ExecutableModule
             [$container->get(SettingAssetsLoader::class), 'load']
         );
 
-        add_action(
-            'init',
-            static function () use ($container): void {
-                $container->get(SettingsRegistrar::class)->registerSettings(
-                    TabbedSettingPage::default(
-                        self::FAU_DEGREE_PROGRAM_SETTINGS,
-                        _x(
-                            'FAU Degree Program',
-                            'backoffice: setting page title',
-                            'fau-degree-program'
-                        ),
-                        Capabilities::READ_DEGREE_PROGRAM_SETTINGS,
-                        Capabilities::EDIT_DEGREE_PROGRAM_SETTINGS,
-                        SettingsPage::default(
-                            self::FAU_DEGREE_PROGRAM_SHARED_PROPERTIES,
-                            _x(
-                                'General',
-                                'backoffice: setting page tab title',
-                                'fau-degree-program'
-                            ),
-                            Capabilities::READ_DEGREE_PROGRAM_SETTINGS,
-                            Capabilities::EDIT_DEGREE_PROGRAM_SETTINGS,
-                            self::degreeProgramSharedPropertiesSection(),
-                        ),
-                        SettingsPage::default(
-                            self::FAU_CONTENT_ITEM_TITLES,
-                            _x(
-                                'Content',
-                                'backoffice: setting page tab title',
-                                'fau-degree-program'
-                            ),
-                            Capabilities::READ_DEGREE_PROGRAM_SETTINGS,
-                            Capabilities::EDIT_DEGREE_PROGRAM_SETTINGS,
-                            self::contentItemTitlesSection(),
-                        ),
-                    ),
-                );
-            }
-        );
+        add_action('init', fn () => $this->registerSettings($container));
 
         return true;
+    }
+
+    /**
+     * Deferred to `init` so translated labels don't load too early (WP 6.7).
+     *
+     * @wp-hook init
+     */
+    private function registerSettings(ContainerInterface $container): void
+    {
+        $container->get(SettingsRegistrar::class)->registerSettings(
+            TabbedSettingPage::default(
+                self::FAU_DEGREE_PROGRAM_SETTINGS,
+                _x(
+                    'FAU Degree Program',
+                    'backoffice: setting page title',
+                    'fau-degree-program'
+                ),
+                Capabilities::READ_DEGREE_PROGRAM_SETTINGS,
+                Capabilities::EDIT_DEGREE_PROGRAM_SETTINGS,
+                SettingsPage::default(
+                    self::FAU_DEGREE_PROGRAM_SHARED_PROPERTIES,
+                    _x(
+                        'General',
+                        'backoffice: setting page tab title',
+                        'fau-degree-program'
+                    ),
+                    Capabilities::READ_DEGREE_PROGRAM_SETTINGS,
+                    Capabilities::EDIT_DEGREE_PROGRAM_SETTINGS,
+                    self::degreeProgramSharedPropertiesSection(),
+                ),
+                SettingsPage::default(
+                    self::FAU_CONTENT_ITEM_TITLES,
+                    _x(
+                        'Content',
+                        'backoffice: setting page tab title',
+                        'fau-degree-program'
+                    ),
+                    Capabilities::READ_DEGREE_PROGRAM_SETTINGS,
+                    Capabilities::EDIT_DEGREE_PROGRAM_SETTINGS,
+                    self::contentItemTitlesSection(),
+                ),
+            ),
+        );
     }
 
     /**

--- a/src/Infrastructure/Dashboard/Settings/SettingsModule.php
+++ b/src/Infrastructure/Dashboard/Settings/SettingsModule.php
@@ -59,39 +59,44 @@ final class SettingsModule implements ServiceModule, ExecutableModule
             [$container->get(SettingAssetsLoader::class), 'load']
         );
 
-        $container->get(SettingsRegistrar::class)->registerSettings(
-            TabbedSettingPage::default(
-                self::FAU_DEGREE_PROGRAM_SETTINGS,
-                _x(
-                    'FAU Degree Program',
-                    'backoffice: setting page title',
-                    'fau-degree-program'
-                ),
-                Capabilities::READ_DEGREE_PROGRAM_SETTINGS,
-                Capabilities::EDIT_DEGREE_PROGRAM_SETTINGS,
-                SettingsPage::default(
-                    self::FAU_DEGREE_PROGRAM_SHARED_PROPERTIES,
-                    _x(
-                        'General',
-                        'backoffice: setting page tab title',
-                        'fau-degree-program'
+        add_action(
+            'init',
+            static function () use ($container): void {
+                $container->get(SettingsRegistrar::class)->registerSettings(
+                    TabbedSettingPage::default(
+                        self::FAU_DEGREE_PROGRAM_SETTINGS,
+                        _x(
+                            'FAU Degree Program',
+                            'backoffice: setting page title',
+                            'fau-degree-program'
+                        ),
+                        Capabilities::READ_DEGREE_PROGRAM_SETTINGS,
+                        Capabilities::EDIT_DEGREE_PROGRAM_SETTINGS,
+                        SettingsPage::default(
+                            self::FAU_DEGREE_PROGRAM_SHARED_PROPERTIES,
+                            _x(
+                                'General',
+                                'backoffice: setting page tab title',
+                                'fau-degree-program'
+                            ),
+                            Capabilities::READ_DEGREE_PROGRAM_SETTINGS,
+                            Capabilities::EDIT_DEGREE_PROGRAM_SETTINGS,
+                            self::degreeProgramSharedPropertiesSection(),
+                        ),
+                        SettingsPage::default(
+                            self::FAU_CONTENT_ITEM_TITLES,
+                            _x(
+                                'Content',
+                                'backoffice: setting page tab title',
+                                'fau-degree-program'
+                            ),
+                            Capabilities::READ_DEGREE_PROGRAM_SETTINGS,
+                            Capabilities::EDIT_DEGREE_PROGRAM_SETTINGS,
+                            self::contentItemTitlesSection(),
+                        ),
                     ),
-                    Capabilities::READ_DEGREE_PROGRAM_SETTINGS,
-                    Capabilities::EDIT_DEGREE_PROGRAM_SETTINGS,
-                    self::degreeProgramSharedPropertiesSection(),
-                ),
-                SettingsPage::default(
-                    self::FAU_CONTENT_ITEM_TITLES,
-                    _x(
-                        'Content',
-                        'backoffice: setting page tab title',
-                        'fau-degree-program'
-                    ),
-                    Capabilities::READ_DEGREE_PROGRAM_SETTINGS,
-                    Capabilities::EDIT_DEGREE_PROGRAM_SETTINGS,
-                    self::contentItemTitlesSection(),
-                ),
-            ),
+                );
+            }
         );
 
         return true;

--- a/src/Infrastructure/Dashboard/TermMeta/TermMetaModule.php
+++ b/src/Infrastructure/Dashboard/TermMeta/TermMetaModule.php
@@ -60,10 +60,25 @@ final class TermMetaModule implements ServiceModule, ExecutableModule
         ];
     }
 
+    public function run(ContainerInterface $container): bool
+    {
+        add_action(
+            'init',
+            fn () => $this->registerTermMeta($container)
+        );
+
+        add_action(
+            AssetManager::ACTION_SETUP,
+            [$container->get(AssetsLoader::class), 'load']
+        );
+
+        return true;
+    }
+
     /**
      * phpcs:disable Inpsyde.CodeQuality.FunctionLength.TooLong
      */
-    public function run(ContainerInterface $container): bool
+    private function registerTermMeta(ContainerInterface $container): void
     {
         $termMetaRegistrar = $container->get(TermMetaRegistrar::class);
 
@@ -161,13 +176,6 @@ final class TermMetaModule implements ServiceModule, ExecutableModule
             ApplyNowLinkTaxonomy::KEY,
             ...(new MultilingualLinkTermMetaFields())->getArrayCopy(),
         );
-
-        add_action(
-            AssetManager::ACTION_SETUP,
-            [$container->get(AssetsLoader::class), 'load']
-        );
-
-        return true;
     }
 
     /**

--- a/src/Infrastructure/Dashboard/TermMeta/TermMetaModule.php
+++ b/src/Infrastructure/Dashboard/TermMeta/TermMetaModule.php
@@ -76,6 +76,9 @@ final class TermMetaModule implements ServiceModule, ExecutableModule
     }
 
     /**
+     * Deferred to `init` so translated labels don't load too early (WP 6.7).
+     *
+     * @wp-hook init
      * phpcs:disable Inpsyde.CodeQuality.FunctionLength.TooLong
      */
     private function registerTermMeta(ContainerInterface $container): void


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-469


**What is the new behavior (if this is a feature change)?**
Defer translations to `init` because building the setting pages calls translation functions, which must not run before `init`.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
